### PR TITLE
Mode1 before fo

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,8 @@
+using Documenter
+
 module PSCOPFDocs
 
-using Documenter, PSCOPF
+using Documenter
 
 format = Documenter.HTML(
     prettyurls = false,
@@ -32,6 +34,11 @@ pages = Any[
                    ],
 
                 "Modèles du TSO" => Any[
+                    "TSO avant la FO" => Any[
+                        "Le Problème" => "2_modeles/2_tso/1_tso_avant_fo/1_problem.md",
+                        "Les Variables et les Contraintes" => "2_modeles/2_tso/1_tso_avant_fo/2_vars_and_cstrs.md",
+                        "L'Objectif" => "2_modeles/2_tso/1_tso_avant_fo/3_objective.md",
+                        ],
                     "Mode 1 (ANCIEN)" => Any[
                         "Problem Description" => "2_modeles/2_tso/1_mode_1/1_problem.md",
                         "Variables" => "2_modeles/2_tso/1_mode_1/2_variables.md",
@@ -50,7 +57,10 @@ pages = Any[
 
 end # PSCOPFDocs
 
-makedocs(modules = [PSCOPF],
+#TODO : PTDF docs go somewhere else
+include(joinpath(@__DIR__, "..", "src", "PSCOPF.jl"))
+include(joinpath(@__DIR__, "..", "src", "PTDF.jl"))
+makedocs(modules = [PSCOPF, PTDF],
         sitename="PSCOPF",
         format = PSCOPFDocs.format,
         pages = PSCOPFDocs.pages,

--- a/docs/src/2_modeles/1_marche/1_marche_de_energie_avant_fo/2_vars_and_cstrs.md
+++ b/docs/src/2_modeles/1_marche/1_marche_de_energie_avant_fo/2_vars_and_cstrs.md
@@ -101,13 +101,11 @@ pmin(gen) B_{on}[gen,ts,s] \le P_{injected}[gen, ts, s] \le pmax(gen) B_{on}[gen
 ```
 
 ## Contrainte EOD
-$P_{cut\_production}(ts,s)$
-
 
 ```math
 \forall ts \in TS, \forall s \in S, \\
 
-\sum_{bus \in BUSES} uncertainties(bus,ts,s) - P_{cut\_consumption}[(]ts,s]
+\sum_{bus \in BUSES} uncertainties(bus,ts,s) - P_{cut\_consumption}[ts,s]
 =
-\sum_{gen \in GENERATORS} P_injected[gen,ts,s] - P_{cut\_production}[(]ts,s]
+\sum_{gen \in GENERATORS} P_injected[gen,ts,s] - P_{cut\_production}[ts,s]
 ```

--- a/docs/src/2_modeles/1_marche/1_marche_de_energie_avant_fo/3_objective.md
+++ b/docs/src/2_modeles/1_marche/1_marche_de_energie_avant_fo/3_objective.md
@@ -7,7 +7,9 @@ Le marché essaye de produire à moindre coût. La fonction objectif consiste à
 Min \\
           & \sum_{ts \in TS;s \in S;\\gen \in GENERATORS} c_{prop}(gen) P_{injected}[gen,ts,s] \\
         + & \sum_{ts \in TS, s \in S;\\ gen \in IMPOSABLES_+\setminus{GRATIS}} c_{start}(gen) B_{start}[gen,ts,s] \\
-        + & \sum_{ts \in S;s \in S} penalty_{cut\_consumption} P_{cut\_consumption}(ts,s) \\
-        + & \sum_{ts \in S;s \in S} penalty_{cut\_production} P_{cut\_production}(ts,s) \\
+        + & \sum_{ts \in S;s \in S} penalty_{cut\_consumption} P_{cut\_consumption}[ts,s] \\
+        + & \sum_{ts \in S;s \in S} penalty_{cut\_production} P_{cut\_production}[ts,s] \\
 \end{aligned}
 ```
+
+ $GRATIS$ est l'ensemble des unités pour lesquels le coût de démarrage a déjà été payé. Il s'agit des unités démarré par le marché ou par le TSO avant l'échéance courante.

--- a/docs/src/2_modeles/2_tso/1_mode_1/3_constraints.md
+++ b/docs/src/2_modeles/2_tso/1_mode_1/3_constraints.md
@@ -35,5 +35,7 @@ This can easily make the problem infeasable.
 \end{aligned}
 ```
 
+Need to add P_cut_prod and cut_conso here !
+
 This constraint expresses the power limits of the network's branches.
 This, actually, represents a thermal real constraint in terms of a power limit constraint.

--- a/docs/src/2_modeles/2_tso/1_tso_avant_fo/3_objective.md
+++ b/docs/src/2_modeles/2_tso/1_tso_avant_fo/3_objective.md
@@ -5,9 +5,24 @@ Le marché essaye de produire à moindre coût. La fonction objectif consiste à
 ```math
 \begin{aligned}
 Min \\
-          & \sum_{ts \in TS;s \in S;\\gen \in GENERATORS} c_{prop}(gen) P_{injected}[gen,ts,s] \\
-        + & \sum_{ts \in TS, s \in S;\\ gen \in IMPOSABLES_+\setminus{GRATIS}} c_{start}(gen) B_{start}[gen,ts,s] \\
-        + & \sum_{ts \in S;s \in S} penalty_{cut\_consumption} P_{cut\_consumption}(ts,s) \\
-        + & \sum_{ts \in S;s \in S} penalty_{cut\_production} P_{cut\_production}(ts,s) \\
+          & \sum_{gen \in GENERATORS} \Delta P^{+}[gen,ts,s]
+        + & \sum_{gen \in GENERATORS} \Delta P^{-}[gen,ts,s] \\
+        + & \sum_{bus \in BUSES, ts \in TS, s \in S} penalty_{cut\_consumption} P_{cut\_consumption}[bus,ts,s] \\
+        + & \sum_{gen \in GENERATORS, ts \in TS;s \in S} penalty_{cut\_production} P_{cut\_production}[gen,ts,s] \\
 \end{aligned}
 ```
+
+puis,
+
+```math
+\begin{aligned}
+Min \\
+          & \sum_{ts \in TS;s \in S;\\gen \in GENERATORS} c_{prop}(gen) P_{injected}[gen,ts,s] \\
+        + & \sum_{ts \in TS, s \in S;\\ gen \in IMPOSABLES_+\setminus{GRATIS}} c_{start}(gen) B_{start}[gen,ts,s] \\
+        + & \sum_{bus \in BUSES, ts \in TS, s \in S} penalty_{cut\_consumption} P_{cut\_consumption}[bus,ts,s] \\
+        + & \sum_{gen \in GENERATORS, ts \in TS;s \in S} penalty_{cut\_production} P_{cut\_production}[gen,ts,s] \\
+\end{aligned}
+```
+
+$GRATIS$ est l'ensemble des unités pour lesquels le coût de démarrage a déjà été payé.
+Souvent, Il s'agirat des unités démarré avant l'échéance courante ou des unité démarré par le marché à l'échéance considérée.

--- a/docs/src/lib/pscopf.md
+++ b/docs/src/lib/pscopf.md
@@ -3,9 +3,9 @@
 For autodoc
 
 ```@index
-Modules = [PSCOPF]
+Modules = [PSCOPF.Data, PSCOPF.Networks, PSCOPF.PSCOPFio, PSCOPF, PTDF]
 ```
 
 ```@autodocs
-Modules = [PSCOPF]
+Modules = [PSCOPF.Data, PSCOPF.Networks, PSCOPF.PSCOPFio, PSCOPF, PTDF]
 ```

--- a/src/PSCOPF.jl
+++ b/src/PSCOPF.jl
@@ -25,6 +25,8 @@ module PSCOPF
     include("steps/energy_market_impl.jl")
     include("steps/energy_market.jl")
     include("steps/energy_market_at_fo.jl")
+    include("steps/tso_impl.jl")
+    include("steps/tso.jl")
     include("steps/steps.jl")
 
     include("sequence_launcher.jl")

--- a/src/abstracts.jl
+++ b/src/abstracts.jl
@@ -17,7 +17,7 @@ Such structure might need to overload the following functions :
 - `affects_tso_schedule(runnable::AbstractRunnable)`
 - `update_tso_schedule!(context::AbstractContext, ech, result, firmness, runnable::AbstractRunnable)`
 - `affects_tso_actions(runnable::AbstractRunnable)`
-- `update_tso_actions!(tso_actions, ech, result, firmness, context::AbstractContext, runnable::AbstractRunnable)`
+- `update_tso_actions!(context::AbstractContext, ech, result, firmness, runnable::AbstractRunnable)`
 """
 abstract type  AbstractRunnable end
 """
@@ -51,7 +51,7 @@ function affects_tso_actions(runnable::AbstractRunnable) return false end
 """
 Updates the TSO actions using the result of run()
 """
-function update_tso_actions!(tso_actions, ech, result, firmness, context::AbstractContext, runnable::AbstractRunnable) end
+function update_tso_actions!(context::AbstractContext, ech, result, firmness, runnable::AbstractRunnable) end
 #FIXME are these compatible with the Assessment step ?
 
 abstract type  AbstractTSO <: AbstractRunnable  end

--- a/src/abstracts.jl
+++ b/src/abstracts.jl
@@ -35,7 +35,7 @@ function affects_market_schedule(runnable::AbstractRunnable) return false end
 """
 Updates the market schedule using the result of run()
 """
-function update_market_schedule!(context::AbstractContext, ech, result, firmness, runnable::AbstractRunnable) end
+function update_market_schedule!(context::AbstractContext, ech, result, firmness, runnable::AbstractRunnable) error("unimplemented") end
 """
 If returns True, will launch the tso_schedule related updates during sequence execution
 """
@@ -43,7 +43,7 @@ function affects_tso_schedule(runnable::AbstractRunnable) return false end
 """
 Updates the TSO schedule using the result of run()
 """
-function update_tso_schedule!(context::AbstractContext, ech, result, firmness, runnable::AbstractRunnable) end
+function update_tso_schedule!(context::AbstractContext, ech, result, firmness, runnable::AbstractRunnable) error("unimplemented") end
 """
 If returns True, will launch the tso actions related updates during sequence execution
 """

--- a/src/bo/networks/generator.jl
+++ b/src/bo/networks/generator.jl
@@ -79,6 +79,17 @@ function get_dp(gen::Generator)
     return gen.dp
 end
 
+################
+##  HELPERS   ##
+################
+
+function is_limitable(generator::Generator)::Bool
+    return get_type(generator) == LIMITABLE
+end
+
+function is_imposable(generator::Generator)::Bool
+    return get_type(generator) == IMPOSABLE
+end
 
 ################
 ## INFO / LOG ##

--- a/src/bo/schedule.jl
+++ b/src/bo/schedule.jl
@@ -317,6 +317,17 @@ function get_prod_value(schedule::Schedule, gen_id::String, ts::Dates.DateTime):
     return get_prod_value(schedule.generator_schedules[gen_id], ts)
 end
 
+function safeget_prod_value(sub_schedule::GeneratorSchedule, ts::Dates.DateTime)::Float64
+    prod = get_prod_value(sub_schedule, ts)
+    if ismissing(prod)
+        msg = @sprintf("Missing production value for ts=%s in schedule %s",
+                        ts, sub_schedule.gen_id)
+        throw( error(msg) )
+    else
+        return prod
+    end
+end
+
 function get_commitment_value(sub_schedule::GeneratorSchedule, ts::Dates.DateTime)::Union{GeneratorState, Missing}
     uncertain_value = get_commitment_uncertain_value(sub_schedule, ts)
     if ismissing(uncertain_value)
@@ -328,6 +339,16 @@ function get_commitment_value(schedule::Schedule, gen_id::String, ts::Dates.Date
     return get_commitment_value(schedule.generator_schedules[gen_id], ts)
 end
 
+function safeget_commitment_value(sub_schedule::GeneratorSchedule, ts::Dates.DateTime)::GeneratorState
+    commitment = get_commitment_value(sub_schedule, ts)
+    if ismissing(commitment)
+        msg = @sprintf("Missing commitment value for ts=%s in schedule %s",
+                        ts, sub_schedule.gen_id)
+        throw( error(msg) )
+    else
+        return commitment
+    end
+end
 
 function get_prod_value(sub_schedule::GeneratorSchedule, ts::Dates.DateTime, scenario::String)::Union{Float64, Missing}
     uncertain_value = get_prod_uncertain_value(sub_schedule, ts)

--- a/src/bo/schedule.jl
+++ b/src/bo/schedule.jl
@@ -292,7 +292,7 @@ function get_sub_schedule(schedule::Schedule, gen_id::String)::Union{GeneratorSc
     if haskey(schedule.generator_schedules, gen_id)
         return schedule.generator_schedules[gen_id]
     else
-        throw( error("no generator schedule was initialized for generator ", sub_schedule.gen_id))
+        throw( error("no generator schedule was initialized for generator ", gen_id))
         #return missing
     end
 end

--- a/src/bo/schedule.jl
+++ b/src/bo/schedule.jl
@@ -56,6 +56,8 @@ end
         SortedDict{String, SortedDict{Dates.DateTime, DecisionFirmness} }()
 end
 
+Base.:(==)(a::Firmness, b::Firmness) = a.commitment==b.commitment && a.power_level==b.power_level
+
 function get_commitment_firmness(firmness::Firmness)
     return firmness.commitment
 end

--- a/src/bo/schedule.jl
+++ b/src/bo/schedule.jl
@@ -301,8 +301,8 @@ function get_prod_uncertain_value(sub_schedule::GeneratorSchedule, ts::Dates.Dat
     if haskey(sub_schedule.production, ts)
         return sub_schedule.production[ts]
     else
-        throw( error("power level schedule is not defined for generator ", sub_schedule.gen_id))
-        #return missing
+        @warn("power level schedule is not defined for generator ", sub_schedule.gen_id)
+        return missing
     end
 end
 function get_prod_uncertain_value(schedule::Schedule, gen_id::String, ts::Dates.DateTime)::Union{UncertainValue{Float64},Missing}

--- a/src/bo/tso_actions.jl
+++ b/src/bo/tso_actions.jl
@@ -20,11 +20,26 @@ end
 function get_limitations(tso_actions::TSOActions)
     return tso_actions.limitations
 end
+function get_limitations(limitations_dict::SortedDict{Tuple{String, Dates.DateTime}, Float64})
+    return limitations_dict
+end
+function get_impositions(impositions_dict::SortedDict{Tuple{String, Dates.DateTime}, Float64})
+    return impositions_dict
+end
 
-function get_limitation(tso_actions::TSOActions, gen_id::String, ts::Dates.DateTime)::Union{Float64, Missing}
+function get_limitation(tso_actions, gen_id::String, ts::Dates.DateTime)::Union{Float64, Missing}
     limitations = get_limitations(tso_actions)
     if !haskey(limitations, (gen_id, ts))
         return missing
+    else
+        return limitations[gen_id, ts]
+    end
+end
+function safeget_limitation(tso_actions, gen_id::String, ts::Dates.DateTime)::Union{Float64, Missing}
+    limitation = get_limitation(tso_actions, gen_id, ts)
+    if ismissing(limitation)
+        msg = @sprintf("Missing limitation value for (gen_id=%s,ts=%s).", gen_id, ts)
+        throw( error(msg) )
     else
         return limitations[gen_id, ts]
     end

--- a/src/context.jl
+++ b/src/context.jl
@@ -111,6 +111,10 @@ function set_current_ech!(context_p::PSCOPFContext, ech::Dates.DateTime)
     context_p.current_ech = ech
 end
 
+function get_tso_actions(context::PSCOPFContext)
+    return context.tso_actions
+end
+
 function get_tso_schedule(context_p::PSCOPFContext)
     return context_p.tso_schedule
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -158,7 +158,7 @@ function definitive_starts(schedule::Schedule, initial_state::SortedDict{String,
             if !is_definitive(current_state)
                 break #if current state is not definitive the following are not neither
 
-            elseif ( (prev_state==OFF) && (get_value(current_state)==ON) )
+            elseif ( (prev_state==OFF) && (get_value(current_state)==ON) ) # unit was started for ts
                 push!(result, (gen_id,ts) )
                 prev_state = get_value(current_state)
                 prev_ts = ts

--- a/src/context.jl
+++ b/src/context.jl
@@ -27,7 +27,7 @@ mutable struct PSCOPFContext <: AbstractContext
     market_flows::SortedDict{Tuple{String, DateTime, String}, Float64}
     tso_flows::SortedDict{Tuple{String, DateTime, String}, Float64}
 
-    out_dir
+    out_dir::Union{String,Nothing}
 end
 
 function PSCOPFContext(network::Networks.Network, target_timepoints::Vector{Dates.DateTime},

--- a/src/data/DataToNetwork.jl
+++ b/src/data/DataToNetwork.jl
@@ -13,6 +13,17 @@ export
 #################
 
 
+"""
+    pscopfdata2network(data::String)::Network
+
+reads the input files and construct a `PSCOPF.Network`
+
+# Arguments
+    - `data::String` : path to the directory containing PSCOPF's input files
+
+# Returns
+    The Network representing the input files
+"""
 function pscopfdata2network(data::String)::Network
     # Init network
     network = Networks.Network(data)

--- a/src/data/PSCOPFio.jl
+++ b/src/data/PSCOPFio.jl
@@ -8,6 +8,8 @@ using Dates
 using Printf
 using DataStructures
 
+OUTPUT_PREFIX = "pscopf_out_"
+
 ##########################
 #   Readers
 ##########################
@@ -284,7 +286,7 @@ end
 
 function write_commitment_schedule(dir_path::String, schedule::PSCOPF.Schedule, prefix="")
     ech = schedule.decision_time
-    commitment_filename_l = joinpath(dir_path, prefix*"commitment_schedule.txt")
+    commitment_filename_l = joinpath(dir_path, OUTPUT_PREFIX*prefix*"commitment_schedule.txt")
     open(commitment_filename_l, "a") do commitment_file_l
         if filesize(commitment_file_l) == 0
             Base.write(commitment_file_l, @sprintf("#%19s%10s%25s%20s%10s%6s%10s\n", "ech", "decider", "name", "ts", "scenario", "value", "firmness"))
@@ -312,7 +314,7 @@ end
 
 function write_production_schedule(dir_path::String, schedule::PSCOPF.Schedule, prefix="")
     ech = schedule.decision_time
-    schedule_filename_l = joinpath(dir_path, prefix*"schedule.txt")
+    schedule_filename_l = joinpath(dir_path, OUTPUT_PREFIX*prefix*"schedule.txt")
     open(schedule_filename_l, "a") do schedule_file_l
         if filesize(schedule_file_l) == 0
             Base.write(schedule_file_l, @sprintf("#%19s%10s%25s%20s%10s%16s%10s\n", "ech", "decider", "name", "ts", "scenario", "value", "firmness"))
@@ -341,7 +343,7 @@ end
 
 function write_flows(dir_path::String, context::PSCOPF.AbstractContext, schedule::PSCOPF.Schedule, prefix="")
     ech = schedule.decision_time
-    flows_filename_l = joinpath(dir_path, prefix*"flows.txt")
+    flows_filename_l = joinpath(dir_path, OUTPUT_PREFIX*prefix*"flows.txt")
 
     flows = PSCOPF.compute_flows(context, schedule)
     open(flows_filename_l, "a") do flows_file_l

--- a/src/data/PSCOPFio.jl
+++ b/src/data/PSCOPFio.jl
@@ -374,6 +374,69 @@ function write(context::PSCOPF.AbstractContext, schedule::PSCOPF.Schedule, prefi
     end
 end
 
+function write(context::PSCOPF.AbstractContext, schedule::PSCOPF.Schedule, uncertainties::PSCOPF.Uncertainties, prefix="")
+    dir_path = context.out_dir
+    if !isnothing(dir_path)
+        mkpath(dir_path)
+        _write(dir_path, schedule, uncertainties, prefix)
+    end
+end
+
+function _write(dir_path::String, schedule::PSCOPF.Schedule, uncertainties::PSCOPF.Uncertainties, prefix="")
+    #FIXME refactor to better reflect the if-else (dependence on busVSgen, limVSimposable, pmin>0 or not)
+
+    ech = schedule.decision_time
+    decider = schedule.decider_type
+    schedule_filename_l = joinpath(dir_path, OUTPUT_PREFIX*prefix*"full_schedule.txt")
+    open(schedule_filename_l, "a") do schedule_file_l
+        if filesize(schedule_file_l) == 0
+            Base.write(schedule_file_l, @sprintf("#%19s%10s%25s%10s%20s%10s%16s%16s%16s%15s%8s%15s\n",
+                                            "ech", "decider", "unit/bus", "PROD/LOAD", "ts", "scenario",
+                                            "power_value", "load_shed", "power_capped", "DP_firmness",
+                                            "ON/OFF", "DMO_firmness",
+                                            ))
+        end
+
+        for (gen_id, gen_schedule) in schedule.generator_schedules
+            for ts in PSCOPF.get_target_timepoints(gen_schedule)
+                power_uncertain_value = PSCOPF.get_prod_uncertain_value(gen_schedule, ts)
+                power_firmness = PSCOPF.is_definitive(power_uncertain_value) ? "FIRM" : "FREE"
+                commitment_uncertain_value = PSCOPF.get_commitment_uncertain_value(gen_schedule, ts)
+                if !ismissing(commitment_uncertain_value)
+                    commitment_firmness = PSCOPF.is_definitive(commitment_uncertain_value) ? "FIRM" : "FREE"
+                else
+                    # generators with pmin=0 are not concerned with commitment
+                    commitment_firmness = "X"
+                end
+                for scenario in PSCOPF.get_scenarios(power_uncertain_value)
+                    power_value = PSCOPF.get_prod_value(gen_schedule, ts, scenario)
+                    load_shed = 0. #this is for buses only
+                    power_capped = PSCOPF.get_capping(schedule, gen_id, ts, scenario)
+                    power_capped = ismissing(power_capped) ? 0. : power_capped #this is limitables only
+                    commitment_value = PSCOPF.get_commitment_value(gen_schedule, ts, scenario)
+                    commitment_value = ismissing(commitment_value) ? "X" : commitment_value
+
+                    Base.write(schedule_file_l, @sprintf("%20s%8s%25s%10s%20s%10s%16.8E%16.8E%16.8E%15s%8s%15s\n",
+                                                    ech, decider, gen_id, "PROD", ts, scenario,
+                                                    power_value, load_shed, power_capped, power_firmness,
+                                                    commitment_value, commitment_firmness)
+                                )
+                end
+            end
+        end
+
+        for ((bus_id,ts,scenario), load_shed) in schedule.cut_conso_by_bus
+            original_load_value = PSCOPF.get_uncertainties(uncertainties, ech, bus_id, ts, scenario)
+            power_value = original_load_value - load_shed
+
+            Base.write(schedule_file_l, @sprintf("%20s%8s%25s%8s%20s%10s%16.8E%16.8E%16.8E%8s%6s%8s\n",
+                                                ech, decider, bus_id, "LOAD", ts, scenario,
+                                                power_value, load_shed, 0., "X",
+                                                "X", "X")
+                        )
+        end
+    end
+end
 
 function write(dir_path::String, context::PSCOPF.AbstractContext;
                 tso_schedule::Bool=true,

--- a/src/kpi_helpers.jl
+++ b/src/kpi_helpers.jl
@@ -36,7 +36,6 @@ function compute_flow(branch_id::String,
                 network::Networks.Network,
                 ts, scenario)
     #FIXME only works in balanced scenarios
-    @warn("TODO: compute_flow does not account for slacks (load cutting)")
     flow = 0.
     for bus in Networks.get_buses(network)
         bus_id = Networks.get_id(bus)
@@ -88,6 +87,7 @@ end
 
 function compute_flows(context::PSCOPFContext,
                         schedule::Schedule)
+    @warn("TODO: compute_flow does not account for slacks (load cutting)")
     ech = schedule.decision_time
     return compute_flows(get_uncertainties(context, ech), schedule, get_network(context),
                         get_target_timepoints(context), get_scenarios(context))

--- a/src/kpi_helpers.jl
+++ b/src/kpi_helpers.jl
@@ -35,6 +35,8 @@ function compute_flow(branch_id::String,
                 schedule::Schedule,
                 network::Networks.Network,
                 ts, scenario)
+    #FIXME only works in balanced scenarios
+    @warn("TODO: compute_flow does not account for slacks (load cutting)")
     flow = 0.
     for bus in Networks.get_buses(network)
         bus_id = Networks.get_id(bus)

--- a/src/sequence_launcher.jl
+++ b/src/sequence_launcher.jl
@@ -94,6 +94,7 @@ function run_step!(context_p::AbstractContext, step::AbstractRunnable, ech, next
         verify_firmness(firmness, context_p.market_schedule,
                         excluded_ids=get_limitables_ids(context_p))
         PSCOPF.PSCOPFio.write(context_p, get_market_schedule(context_p), "market_")
+        PSCOPF.PSCOPFio.write(context_p, get_market_schedule(context_p), get_uncertainties(context_p), "market_")
         update_market_flows!(context_p)
         trace_flows(get_market_flows(context_p), get_network(context_p))
     end
@@ -108,6 +109,7 @@ function run_step!(context_p::AbstractContext, step::AbstractRunnable, ech, next
         verify_firmness(firmness, context_p.tso_schedule,
                         excluded_ids=get_limitables_ids(context_p))
         PSCOPF.PSCOPFio.write(context_p, get_tso_schedule(context_p), "tso_")
+        PSCOPF.PSCOPFio.write(context_p, get_market_schedule(context_p), get_uncertainties(context_p), "tso_")
         update_tso_flows!(context_p) #FIXME compute_flows does not account for slacks
         trace_flows(get_tso_flows(context_p), get_network(context_p))
     end

--- a/src/sequence_launcher.jl
+++ b/src/sequence_launcher.jl
@@ -101,9 +101,9 @@ function run_step!(context_p::AbstractContext, step::AbstractRunnable, ech, next
         #TODO : error if !verify
         verify_firmness(firmness, context_p.tso_schedule,
                         excluded_ids=get_limitables_ids(context_p))
-        # PSCOPF.PSCOPFio.write(context_p, get_tso_schedule(context_p), "tso_")
-        # update_tso_flows!(context_p) #FIXME compute_flows does not account for slacks
-        # trace_flows(get_tso_flows(context_p), get_network(context_p))
+        PSCOPF.PSCOPFio.write(context_p, get_tso_schedule(context_p), "tso_")
+        update_tso_flows!(context_p) #FIXME compute_flows does not account for slacks
+        trace_flows(get_tso_flows(context_p), get_network(context_p))
     end
 
     if affects_tso_actions(step)

--- a/src/sequence_launcher.jl
+++ b/src/sequence_launcher.jl
@@ -59,6 +59,11 @@ end
 ###############################################
 
 function init!(context_p::AbstractContext, sequence_p::Sequence, check_context::Bool)
+    if !isnothing(context_p.out_dir)
+        @warn("removing files that start with $(PSCOPFio.OUTPUT_PREFIX) in $(context_p.out_dir)")
+        rm_prefixed(context_p.out_dir, PSCOPFio.OUTPUT_PREFIX)
+    end
+
     println("Lancement du mode : ", context_p.management_mode.name)
     println("Dates d'interet : ", get_target_timepoints(context_p))
     set_horizon_timepoints(context_p, get_timepoints(sequence_p))

--- a/src/sequence_launcher.jl
+++ b/src/sequence_launcher.jl
@@ -75,6 +75,7 @@ function init!(context_p::AbstractContext, sequence_p::Sequence, check_context::
 end
 
 function run_step!(context_p::AbstractContext, step::AbstractRunnable, ech, next_ech)
+    println("-"^20)
     println(typeof(step), " à l'échéance ", ech)
     firmness = compute_firmness(step, ech, next_ech,
                             get_target_timepoints(context_p), context_p)

--- a/src/sequence_launcher.jl
+++ b/src/sequence_launcher.jl
@@ -102,14 +102,14 @@ function run_step!(context_p::AbstractContext, step::AbstractRunnable, ech, next
         verify_firmness(firmness, context_p.tso_schedule,
                         excluded_ids=get_limitables_ids(context_p))
         # PSCOPF.PSCOPFio.write(context_p, get_tso_schedule(context_p), "tso_")
-        # update_tso_flows!(context_p)
+        # update_tso_flows!(context_p) #FIXME compute_flows does not account for slacks
         # trace_flows(get_tso_flows(context_p), get_network(context_p))
     end
 
     if affects_tso_actions(step)
         println("update TSO actions based on optimization results")
-        update_tso_actions!(context_p.tso_actions,
-                            ech, result, firmness, context_p, step)
+        update_tso_actions!(context_p,
+                            ech, result, firmness, step)
         # verify_firmness(firmness, context_p.tso_actions)
     end
 

--- a/src/steps/common.jl
+++ b/src/steps/common.jl
@@ -1,3 +1,6 @@
+using JuMP
+using Dates
+
 try
     using Xpress;
     global OPTIMIZER = Xpress.Optimizer
@@ -57,17 +60,16 @@ function get_status(model_container_p::AbstractModelContainer)::PSCOPFStatus
     end
 end
 
-function solve!(model_container::AbstractModelContainer,
+function solve!(model::Model,
                 problem_name="problem", out_folder=nothing,
                 optimizer=OPTIMIZER)
     problem_name_l = replace(problem_name, ":"=>"_")
-    model_l = get_model(model_container)
-    set_optimizer(model_l, optimizer);
+    set_optimizer(model, optimizer);
 
     if !isnothing(out_folder)
         mkpath(out_folder)
         model_file_l = joinpath(out_folder, problem_name_l*".lp")
-        write_to_file(model_l, model_file_l)
+        write_to_file(model, model_file_l)
 
         log_file_l = joinpath(out_folder, problem_name_l*".log")
     else
@@ -75,13 +77,9 @@ function solve!(model_container::AbstractModelContainer,
     end
 
     redirect_to_file(log_file_l) do
-        optimize!(model_l)
+        optimize!(model)
     end
 end
-
-
-
-
 
 
 abstract type AbstractGeneratorModel end
@@ -91,3 +89,140 @@ abstract type AbstractLimitableModel <: AbstractGeneratorModel end
 abstract type AbstractSlackModel end
 
 abstract type AbstractObjectiveModel end
+
+
+# AbstractGeneratorModel
+############################
+
+function add_p_injected!(generator_model::AbstractGeneratorModel, model::Model,
+                        gen_id::String, ts::DateTime, s::String,
+                        p_max::Float64,
+                        force_to_max::Bool
+                        )
+    name =  @sprintf("P_injected[%s,%s,%s]", gen_id, ts, s)
+
+    if force_to_max
+        generator_model.p_injected[gen_id, ts, s] = @variable(model, base_name=name,
+                                                        lower_bound=p_max, upper_bound=p_max)
+    else
+        generator_model.p_injected[gen_id, ts, s] = @variable(model, base_name=name,
+                                                        lower_bound=0., upper_bound=p_max)
+    end
+
+    return generator_model.p_injected[gen_id, ts, s]
+end
+
+function sum_injections(generator_model::AbstractGeneratorModel,
+                        ts::Dates.DateTime, s::String)::AffExpr
+    sum_l = AffExpr(0)
+    for ((_,ts_l,s_l), var_l) in generator_model.p_injected
+        if (ts_l,s_l) == (ts, s)
+            sum_l += var_l
+        end
+    end
+    return sum_l
+end
+
+# AbstractImposableModel
+############################
+
+function add_commitment!(imposable_model::AbstractImposableModel, model::Model,
+                        generator::Networks.Generator,
+                        target_timepoints::Vector{Dates.DateTime},
+                        scenarios::Vector{String},
+                        generator_initial_state::GeneratorState
+                        )
+    p_injected_vars = imposable_model.p_injected
+    b_on_vars = imposable_model.b_on
+    b_start_vars = imposable_model.b_start
+
+    gen_id = Networks.get_id(generator)
+    p_max = Networks.get_p_max(generator)
+    p_min = Networks.get_p_min(generator)
+    for s in scenarios
+        for (ts_index, ts) in enumerate(target_timepoints)
+            name =  @sprintf("B_on[%s,%s,%s]", gen_id, ts, s)
+            b_on_vars[gen_id, ts, s] = @variable(model, base_name=name, binary=true)
+            name =  @sprintf("B_start[%s,%s,%s]", gen_id, ts, s)
+            b_start_vars[gen_id, ts, s] = @variable(model, base_name=name, binary=true)
+
+            # pmin < P_injected < pmax OR = 0
+            @constraint(model, p_injected_vars[gen_id, ts, s] <= p_max * b_on_vars[gen_id, ts, s]);
+            @constraint(model, p_injected_vars[gen_id, ts, s] >= p_min * b_on_vars[gen_id, ts, s]);
+
+            #commitment_constraints
+            preceding_on = (ts_index > 1) ? b_on_vars[gen_id, target_timepoints[ts_index-1], s] : float(generator_initial_state)
+            @constraint(model, b_start_vars[gen_id, ts, s] <= b_on_vars[gen_id, ts, s])
+            @constraint(model, b_start_vars[gen_id, ts, s] <= 1 - preceding_on)
+            @constraint(model, b_start_vars[gen_id, ts, s] >= b_on_vars[gen_id, ts, s] - preceding_on)
+        end
+    end
+
+    return imposable_model, model
+end
+
+# Utils
+##################
+
+function link_scenarios!(model::Model, vars::AbstractDict{Tuple{String,DateTime,String},VariableRef},
+                        gen_id::String, ts::DateTime, scenarios::Vector{String})
+    s1 = scenarios[1]
+    for (s_index, s) in enumerate(scenarios)
+        if s_index > 1
+            @constraint(model, vars[gen_id, ts, s] == vars[gen_id, ts, s1]);
+        end
+    end
+    return model
+end
+
+function add_commitment_firmness_constraints!(model::Model,
+                                            generator::Networks.Generator,
+                                            b_on_vars::SortedDict{Tuple{String,DateTime,String},VariableRef},
+                                            target_timepoints::Vector{Dates.DateTime},
+                                            scenarios::Vector{String},
+                                            commitment_firmness::SortedDict{Dates.DateTime, DecisionFirmness}, #by ts
+                                            generator_reference_schedule::GeneratorSchedule
+                                            )
+    gen_id = Networks.get_id(generator)
+    for ts in target_timepoints
+        if commitment_firmness[ts] in [DECIDED, TO_DECIDE]
+            link_scenarios!(model, b_on_vars, gen_id, ts, scenarios)
+        end
+
+        if commitment_firmness[ts] == DECIDED
+            val = float(safeget_commitment_value(generator_reference_schedule, ts))
+            for s in scenarios
+                @assert( !has_upper_bound(b_on_vars[gen_id, ts, s]) || (val <= upper_bound(b_on_vars[gen_id, ts, s])) )
+                @constraint(model, b_on_vars[gen_id, ts, s] == val)
+            end
+        end
+    end
+
+    return model
+end
+
+function add_power_level_firmness_constraints!(model::Model,
+                                                generator::Networks.Generator,
+                                                p_injected_vars::SortedDict{Tuple{String,DateTime,String},VariableRef},
+                                                target_timepoints::Vector{Dates.DateTime},
+                                                scenarios::Vector{String},
+                                                power_level_firmness::SortedDict{Dates.DateTime, DecisionFirmness}, #by ts
+                                                generator_reference_schedule::GeneratorSchedule
+                                                )
+    gen_id = Networks.get_id(generator)
+    for ts in target_timepoints
+        if power_level_firmness[ts] in [DECIDED, TO_DECIDE]
+            link_scenarios!(model, p_injected_vars, gen_id, ts, scenarios)
+        end
+
+        if power_level_firmness[ts] == DECIDED
+            val = safeget_prod_value(generator_reference_schedule,ts)
+            for s in scenarios
+                @assert( !has_upper_bound(p_injected_vars[gen_id, ts, s]) || (val <= upper_bound(p_injected_vars[gen_id, ts, s])) )
+                @constraint(model, p_injected_vars[gen_id, ts, s] == val)
+            end
+        end
+    end
+
+    return model
+end

--- a/src/steps/common.jl
+++ b/src/steps/common.jl
@@ -141,7 +141,11 @@ end
 
 # AbstractLimitableModel
 ############################
-
+#FIXME
+# maybe just have P_injected[g,ts,s] <= P_limit[g,ts] and add +0.001*Plimit in Min objective
+# is_limited(g,ts,s) will be computed outside the model by checking if uncertainty[g,ts,s] > Plimit[g,ts]
+# which will reduce the number of discrte variables
+# + it will allow Pinjected to be less than the uncertainty (c.f. )
 function add_p_limit!(limitable_model::AbstractLimitableModel, model::Model,
                         gen_id::String, ts::Dates.DateTime,
                         scenarios::Vector{String},

--- a/src/steps/common.jl
+++ b/src/steps/common.jl
@@ -147,11 +147,6 @@ end
 
 # AbstractLimitableModel
 ############################
-#FIXME
-# maybe just have P_injected[g,ts,s] <= P_limit[g,ts] and add +0.001*Plimit in Min objective
-# is_limited(g,ts,s) will be computed outside the model by checking if uncertainty[g,ts,s] > Plimit[g,ts]
-# which will reduce the number of discrte variables
-# + it will allow Pinjected to be less than the uncertainty (c.f. )
 function add_p_limit!(limitable_model::AbstractLimitableModel, model::Model,
                         gen_id::String, ts::Dates.DateTime,
                         scenarios::Vector{String},
@@ -160,37 +155,13 @@ function add_p_limit!(limitable_model::AbstractLimitableModel, model::Model,
                         decision_firmness::DecisionFirmness, #by ts
                         preceding_limit::Union{Float64, Missing}
                         )
-    b_is_limited = limitable_model.b_is_limited
-    p_limit_x_is_limited = limitable_model.p_limit_x_is_limited
-
+    #NOTE : need to add p_limit in Min objective
     name =  @sprintf("P_limit[%s,%s]", gen_id, ts)
     limitable_model.p_limit[gen_id, ts] = @variable(model, base_name=name, lower_bound=0., upper_bound=pmax)
     limit_var = limitable_model.p_limit[gen_id, ts]
     for s in scenarios
         injection_var = limitable_model.p_injected[gen_id, ts, s]
-
-        name =  @sprintf("B_is_limited[%s,%s,%s]", gen_id, ts, s)
-        b_is_limited_var = b_is_limited[gen_id, ts, s] = @variable(model, base_name=name, binary=true)
-
-        name =  @sprintf("P_limit_x_is_limited[%s,%s,%s]", gen_id, ts, s)
-        p_limit_x_is_limited[gen_id, ts, s] = add_prod_vars!(model,
-                                                            limit_var,
-                                                            b_is_limited[gen_id, ts, s],
-                                                            pmax,
-                                                            name
-                                                            )
-
-        p_enr = min(get_uncertainties(inject_uncertainties, ts, s), pmax)
-
-        #inj[g,ts,s] = min{p_limit[g,ts], uncertainties(g,ts,s), pmax(g)}
         @constraint(model, injection_var <= limit_var)
-        @constraint(model, injection_var <=
-                        (1-b_is_limited[gen_id, ts, s]) * p_enr + p_limit_x_is_limited[gen_id, ts, s]
-                        )
-
-        #b_is_limited_var==0 <=> Plim >= uncertainty
-        @constraint(model, limit_var <= p_enr*b_is_limited_var + pmax*(1-b_is_limited_var) )
-        @constraint(model, limit_var >= p_enr*(1-b_is_limited_var) )
     end
 
     if decision_firmness==DECIDED
@@ -201,6 +172,12 @@ function add_p_limit!(limitable_model::AbstractLimitableModel, model::Model,
     end
 
     return limitable_model, model
+end
+
+function is_limited(gen_id, ts, s, limitable_model, uncertainties_at_ech)
+    injected = value(limitable_model.p_injected[gen_id, ts, s])
+    available = get_uncertainties(uncertainties_at_ech, gen_id, ts, s)
+    return ( injected < available-1e-09 )
 end
 
 # AbstractImposableModel

--- a/src/steps/common.jl
+++ b/src/steps/common.jl
@@ -88,4 +88,6 @@ abstract type AbstractGeneratorModel end
 abstract type AbstractImposableModel <: AbstractGeneratorModel end
 abstract type AbstractLimitableModel <: AbstractGeneratorModel end
 
+abstract type AbstractSlackModel end
+
 abstract type AbstractObjectiveModel end

--- a/src/steps/energy_market.jl
+++ b/src/steps/energy_market.jl
@@ -4,7 +4,8 @@ using Dates
 using JuMP
 using Printf
 
-struct EnergyMarket <: AbstractMarket
+@with_kw mutable struct EnergyMarket <: AbstractMarket
+    configs = EnergyMarketConfigs()
 end
 
 function run(runnable::EnergyMarket,
@@ -23,6 +24,9 @@ function run(runnable::EnergyMarket,
     market_starts = definitive_starts(get_market_schedule(context), get_generators_initial_state(context))
     gratis_starts = union(tso_starts, market_starts)
 
+    runnable.configs.out_path = context.out_dir
+    runnable.configs.problem_name = problem_name_l
+
     return energy_market(get_network(context),
                         TS,
                         get_generators_initial_state(context),
@@ -31,8 +35,7 @@ function run(runnable::EnergyMarket,
                         firmness,
                         get_market_schedule(context),
                         gratis_starts,
-                        out_path=context.out_dir,
-                        problem_name=problem_name_l,
+                        runnable.configs
                         )
 end
 

--- a/src/steps/energy_market.jl
+++ b/src/steps/energy_market.jl
@@ -66,10 +66,8 @@ function update_market_schedule!(context::AbstractContext, ech,
         gen_state_value = parse(GeneratorState, value(b_on_var))
         if get_commitment_firmness(firmness, gen_id, ts) == FREE
             set_commitment_value!(market_schedule, gen_id, ts, s, gen_state_value)
-        elseif get_commitment_firmness(firmness, gen_id, ts) == TO_DECIDE
+        elseif get_commitment_firmness(firmness, gen_id, ts) in [TO_DECIDE, DECIDED]
             set_commitment_definitive_value!(market_schedule, gen_id, ts, gen_state_value)
-        elseif get_commitment_firmness(firmness, gen_id, ts) == DECIDED
-            @assert( gen_state_value == get_commitment_value(market_schedule, gen_id, ts) )
         end
     end
 

--- a/src/steps/energy_market.jl
+++ b/src/steps/energy_market.jl
@@ -47,13 +47,7 @@ function update_market_schedule!(context::AbstractContext, ech,
 
 
     for ((gen_id, ts, s), p_injected_var) in result.limitable_model.p_injected
-        if get_power_level_firmness(firmness, gen_id, ts) == FREE
-            set_prod_value!(market_schedule, gen_id, ts, s, value(p_injected_var))
-        elseif get_power_level_firmness(firmness, gen_id, ts) == TO_DECIDE
-            set_prod_definitive_value!(market_schedule, gen_id, ts, value(p_injected_var))
-        elseif get_power_level_firmness(firmness, gen_id, ts) == DECIDED
-            @assert( value(p_injected_var) == get_prod_value(market_schedule, gen_id, ts) )
-        end
+        set_prod_value!(market_schedule, gen_id, ts, s, value(p_injected_var))
     end
     for ((gen_id, ts, s), p_injected_var) in result.imposable_model.p_injected
         if get_power_level_firmness(firmness, gen_id, ts) == FREE

--- a/src/steps/energy_market_at_fo.jl
+++ b/src/steps/energy_market_at_fo.jl
@@ -99,5 +99,12 @@ function update_market_schedule!(context::AbstractContext, ech,
         set_commitment_definitive_value!(market_schedule, gen_id, ts, gen_state_value)
     end
 
+    # TODO : may need to adapt cause result handles only one scenario
+    # Capping
+    update_schedule_capping!(market_schedule, context, ech, result.limitable_model)
+
+    # cut_conso (load-shedding)
+    update_schedule_cut_conso!(market_schedule, context, ech, result.slack_model)
+
     return market_schedule
 end

--- a/src/steps/energy_market_at_fo.jl
+++ b/src/steps/energy_market_at_fo.jl
@@ -5,7 +5,8 @@ using JuMP
 using Statistics
 using Printf
 
-struct EnergyMarketAtFO <: AbstractMarket
+@with_kw mutable struct EnergyMarketAtFO <: AbstractMarket
+    configs = EnergyMarketConfigs()
 end
 
 SCENARIOS_DELIMITER = "_+_"
@@ -59,6 +60,9 @@ function run(runnable::EnergyMarketAtFO,
     @assert check_uncertainties(Uncertainties(ech=>agg_uncertainties), get_network(context))
     @assert check_uncertainties_contain_ts(Uncertainties(ech=>agg_uncertainties), get_target_timepoints(context))
 
+    runnable.configs.out_path = context.out_dir
+    runnable.configs.problem_name = problem_name_l
+
     return energy_market(get_network(context),
                         TS,
                         get_generators_initial_state(context),
@@ -67,8 +71,7 @@ function run(runnable::EnergyMarketAtFO,
                         firmness,
                         get_market_schedule(context), #this uses original scenario names
                         gratis_starts,
-                        out_path=context.out_dir,
-                        problem_name=problem_name_l,
+                        runnable.configs
                         )
 end
 

--- a/src/steps/energy_market_at_fo.jl
+++ b/src/steps/energy_market_at_fo.jl
@@ -86,9 +86,6 @@ function update_market_schedule!(context::AbstractContext, ech,
 
     for ((gen_id, ts, _), p_injected_var) in result.limitable_model.p_injected
         set_prod_definitive_value!(market_schedule, gen_id, ts, value(p_injected_var))
-        if get_power_level_firmness(firmness, gen_id, ts) == DECIDED
-            @assert( value(p_injected_var) == get_prod_value(market_schedule, gen_id, ts) )
-        end
     end
     for ((gen_id, ts, s), p_injected_var) in result.imposable_model.p_injected
         set_prod_definitive_value!(market_schedule, gen_id, ts, value(p_injected_var))
@@ -100,9 +97,6 @@ function update_market_schedule!(context::AbstractContext, ech,
     for ((gen_id, ts, _), b_on_var) in result.imposable_model.b_on
         gen_state_value = parse(GeneratorState, value(b_on_var))
         set_commitment_definitive_value!(market_schedule, gen_id, ts, gen_state_value)
-        if get_commitment_firmness(firmness, gen_id, ts) == DECIDED
-            @assert( gen_state_value == get_commitment_value(market_schedule, gen_id, ts) )
-        end
     end
 
     return market_schedule

--- a/src/steps/energy_market_impl.jl
+++ b/src/steps/energy_market_impl.jl
@@ -130,7 +130,7 @@ function energy_market(network::Networks.Network,
     return model_container_l
 end
 
-function add_objective!(model_container, network, gratis_starts, cut_conso_cost)
+function add_objective!(model_container::EnergyMarketModel, network, gratis_starts, cut_conso_cost)
     # No cost for starting limitables
 
     # cost for starting imposables

--- a/src/steps/energy_market_impl.jl
+++ b/src/steps/energy_market_impl.jl
@@ -201,7 +201,9 @@ function add_imposable!(imposable_model::EnergyMarketImposableModel, model::Mode
                         )
         add_commitment_firmness_constraints!(model, generator,
                                             imposable_model.b_on,
+                                            imposable_model.b_start,
                                             target_timepoints, scenarios,
+                                            generator_initial_state,
                                             commitment_firmness,
                                             generator_reference_schedule
                                             )

--- a/src/steps/energy_market_impl.jl
+++ b/src/steps/energy_market_impl.jl
@@ -58,6 +58,10 @@ end
     status::PSCOPFStatus = pscopf_UNSOLVED
 end
 
+function has_positive_slack(model_container::EnergyMarketModel)::Bool
+    return has_positive_value(model_container.slack_model.p_cut_conso)
+end
+
 """
     energy_market
 # Arguments

--- a/src/steps/steps.jl
+++ b/src/steps/steps.jl
@@ -64,8 +64,8 @@ function update_tso_schedule!(context::AbstractContext, ech, result, firmness,
             " en me basant sur les résultats d'optimisation.")
     println("\tet je ne touche pas au planning du marché")
 end
-function update_tso_actions!(tso_actions, ech, result, firmness,
-                            context::AbstractContext, runnable::AbstractTSO)
+function update_tso_actions!(context::AbstractContext, ech, result, firmness,
+                            runnable::AbstractTSO)
     println("\tJe mets à jour les actions TSO (limitations, impositions) à prendre en compte par le marché")
 end
 

--- a/src/steps/steps.jl
+++ b/src/steps/steps.jl
@@ -7,21 +7,6 @@ using Dates
 ################################################################################
 
 """
-utilisé dans les trois modes
-Prend des décisions en se référençant à une situation équilibrée par le marché
-N'utilise pas la reserve ?
-"""
-struct TSOOutFO <: AbstractTSO
-end
-function run(runnable::TSOOutFO, ech::Dates.DateTime, firmness, TS::Vector{Dates.DateTime}, context::AbstractContext)
-    println("\tJe me référencie au précédent planning du marché pour les arrets/démarrage et l'estimation des couts : ",
-            get_market_schedule(context).decider_type, ",", get_market_schedule(context).decision_time)
-    println("\tJe me référencie à mon précédent planning du TSO pour les arrets/démarrage : ",
-            get_tso_schedule(context).decider_type, ",", get_tso_schedule(context).decision_time)
-    return #result
-end
-
-"""
 utilisé pour le mode 3:
 Prend des décisions fermes vu que c'est la dernière execution du TSO
 Décide de la reserve

--- a/src/steps/tso.jl
+++ b/src/steps/tso.jl
@@ -84,7 +84,7 @@ function update_tso_actions!(context::AbstractContext, ech, result, firmness,
     tso_actions = get_tso_actions(context)
     println("\tJe mets à jour les actions TSO (limitations, impositions) à prendre en compte par le marché")
 
-    # Limitations
+    # Limitations : FIXME ; limit only if there is a limitation needed !
     for ((gen_id, ts), p_limit_var) in result.limitable_model.p_limit
         if get_power_level_firmness(firmness, gen_id, ts) in [TO_DECIDE, DECIDED]
             set_limitation_value!(tso_actions, gen_id, ts, value(p_limit_var))

--- a/src/steps/tso.jl
+++ b/src/steps/tso.jl
@@ -1,0 +1,85 @@
+using .Networks
+
+using Dates
+using JuMP
+using Printf
+using Parameters
+
+@with_kw struct TSOOutFO <: AbstractTSO
+    configs::TSOConfigs = TSOConfigs()
+end
+
+function run(runnable::TSOOutFO, ech::Dates.DateTime, firmness, TS::Vector{Dates.DateTime}, context::AbstractContext)
+    println("\tJe me référencie au précédent planning du marché pour les arrets/démarrage et l'estimation des couts : ",
+            get_market_schedule(context).decider_type, ",", get_market_schedule(context).decision_time)
+    println("\tJe me référencie à mon précédent planning du TSO pour les arrets/démarrage : ",
+            get_tso_schedule(context).decider_type, ",", get_tso_schedule(context).decision_time)
+
+    fo_start_time = TS[1] - get_fo_length(get_management_mode(context))
+    if fo_start_time <= ech
+        msg = @sprintf("invalid step at ech=%s : TSOOutFO needs to be launched before FO start (ie %s)", ech, fo_start_time)
+        throw( error(msg) )
+    end
+
+    problem_name_l = @sprintf("tso_out_fo_%s", ech)
+
+    tso_starts = definitive_starts(get_tso_schedule(context), get_generators_initial_state(context))
+    market_starts = definitive_starts(get_market_schedule(context), get_generators_initial_state(context))
+    gratis_starts = union(tso_starts, market_starts)
+
+    runnable.configs.out_path = context.out_dir
+    runnable.configs.problem_name = problem_name_l
+
+    return tso_out_fo(get_network(context),
+                    TS,
+                    get_generators_initial_state(context),
+                    get_scenarios(context, ech),
+                    get_uncertainties(context, ech),
+                    firmness,
+                    get_market_schedule(context),
+                    get_tso_schedule(context),
+                    get_tso_actions(context),
+                    gratis_starts,
+                    runnable.configs
+                    )
+end
+
+function update_tso_schedule!(context::AbstractContext, ech, result, firmness,
+                            runnable::TSOOutFO)
+    tso_schedule = get_tso_schedule(context)
+    tso_schedule.decider_type = DeciderType(runnable)
+    tso_schedule.decision_time = ech
+    println("\tJe mets à jour le planning tso: ",
+    tso_schedule.decider_type, ",",tso_schedule.decision_time,
+    " en me basant sur les résultats d'optimisation.")
+    println("\tet je ne touche pas au planning du marché")
+
+    for ((gen_id, ts, s), p_injected_var) in result.limitable_model.p_injected
+        set_prod_value!(tso_schedule, gen_id, ts, s, value(p_injected_var))
+    end
+    for ((gen_id, ts, s), p_injected_var) in result.imposable_model.p_injected
+        if get_power_level_firmness(firmness, gen_id, ts) == FREE
+            set_prod_value!(tso_schedule, gen_id, ts, s, value(p_injected_var))
+        elseif get_power_level_firmness(firmness, gen_id, ts) == TO_DECIDE
+            set_prod_definitive_value!(tso_schedule, gen_id, ts, value(p_injected_var))
+        elseif get_power_level_firmness(firmness, gen_id, ts) == DECIDED
+            @assert( value(p_injected_var) ≈ get_prod_value(tso_schedule, gen_id, ts) )
+        end
+    end
+
+    for ((gen_id, ts, s), b_on_var) in result.imposable_model.b_on
+        gen_state_value = parse(GeneratorState, value(b_on_var))
+        if get_commitment_firmness(firmness, gen_id, ts) == FREE
+            set_commitment_value!(tso_schedule, gen_id, ts, s, gen_state_value)
+        elseif get_commitment_firmness(firmness, gen_id, ts) in [TO_DECIDE, DECIDED]
+            set_commitment_definitive_value!(tso_schedule, gen_id, ts, gen_state_value)
+        end
+    end
+
+    return tso_schedule
+end
+
+function update_tso_actions!(tso_actions, ech, result, firmness,
+                            context::AbstractContext, runnable::TSOOutFO)
+    println("\tJe mets à jour les actions TSO (limitations, impositions) à prendre en compte par le marché")
+end

--- a/src/steps/tso_impl.jl
+++ b/src/steps/tso_impl.jl
@@ -72,6 +72,9 @@ end
     status::PSCOPFStatus = pscopf_UNSOLVED
 end
 
+function has_positive_slack(model_container::TSOModel)::Bool
+    return has_positive_value(model_container.slack_model.p_cut_conso)
+end
 
 function get_p_injected(model_container::TSOModel, type::Networks.GeneratorType)
     if type == Networks.LIMITABLE

--- a/src/steps/tso_impl.jl
+++ b/src/steps/tso_impl.jl
@@ -20,10 +20,6 @@ end
     delta_p = SortedDict{Tuple{String,DateTime,String},VariableRef}();
     #gen,ts
     p_limit = SortedDict{Tuple{String,DateTime},VariableRef}();
-    #gen,ts,s
-    b_is_limited = Dict{Tuple{String,DateTime,String},VariableRef}();
-    #gen,ts,s
-    p_limit_x_is_limited = Dict{Tuple{String,DateTime,String},VariableRef}();
 end
 
 @with_kw struct TSOImposableModel <: AbstractImposableModel
@@ -113,7 +109,7 @@ function add_limitable!(limitable_model::TSOLimitableModel, model::Model,
     gen_pmax = Networks.get_p_max(generator)
     for ts in target_timepoints
         for s in scenarios
-            p_enr = min(gen_pmax, inject_uncertainties[ts][s]) #FIXME and limit induced by the TSO, potentially (for other markets, this for now does not look at the TSO constraints)
+            p_enr = min(gen_pmax, inject_uncertainties[ts][s])
             add_p_injected!(limitable_model, model, gen_id, ts, s, p_enr, false)
             p_ref = get_prod_value(preceding_market_subschedule, ts, s)
             p_ref = ismissing(p_ref) ? 0. : p_ref
@@ -215,7 +211,6 @@ function add_imposables!(model_container::TSOModel, network::Networks.Network,
     for imposable_gen in imposable_generators
         gen_id = Networks.get_id(imposable_gen)
         gen_initial_state = get_initial_state(generators_initial_state, imposable_gen)
-        println("IMPOSABLE: ", gen_id)
         add_imposable!(model_container.imposable_model, model_container.model,
                         imposable_gen,
                         target_timepoints,
@@ -331,9 +326,9 @@ function create_objectives!(model_container::TSOModel, network, gratis_starts, c
     add_cut_conso_cost!(model_container.objective_model.penalty,
                         model_container.slack_model.p_cut_conso, cut_conso_cost)
 
-    # avoid limiting when not necessary
-    for (_, var_is_limited) in model_container.limitable_model.b_is_limited
-        model_container.objective_model.penalty += 1e-03 * var_is_limited
+    # to force Plim = max(Pinj)
+    for (_, var_limit) in model_container.limitable_model.p_limit
+        model_container.objective_model.penalty += 1e-03 * var_limit
     end
 
     ## Objective 1 :

--- a/src/steps/tso_impl.jl
+++ b/src/steps/tso_impl.jl
@@ -112,8 +112,9 @@ function add_limitable!(limitable_model::TSOLimitableModel, model::Model,
         for s in scenarios
             p_enr = min(gen_pmax, inject_uncertainties[ts][s]) #FIXME and limit induced by the TSO, potentially (for other markets, this for now does not look at the TSO constraints)
             add_p_injected!(limitable_model, model, gen_id, ts, s, p_enr, false)
-            add_p_delta!(limitable_model, model, gen_id, ts, s,
-                        get_prod_value(preceding_market_subschedule, ts, s))
+            p_ref = get_prod_value(preceding_market_subschedule, ts, s)
+            p_ref = ismissing(p_ref) ? 0. : p_ref
+            add_p_delta!(limitable_model, model, gen_id, ts, s, p_ref)
         end
 
         add_p_limit!(limitable_model, model, gen_id, ts, scenarios, gen_pmax,
@@ -169,8 +170,9 @@ function add_imposable!(imposable_model::TSOImposableModel, model::Model,
     for ts in target_timepoints
         for s in scenarios
             add_p_injected!(imposable_model, model, gen_id, ts, s, p_max, false)
-            add_p_delta!(imposable_model, model, gen_id, ts, s,
-                        get_prod_value(preceding_market_subschedule, ts, s))
+            p_ref = get_prod_value(preceding_market_subschedule, ts, s)
+            p_ref = ismissing(p_ref) ? 0. : p_ref
+            add_p_delta!(imposable_model, model, gen_id, ts, s, p_ref)
         end
     end
 

--- a/src/steps/tso_impl.jl
+++ b/src/steps/tso_impl.jl
@@ -1,0 +1,409 @@
+using .Networks
+
+using JuMP
+using Dates
+using DataStructures
+using Printf
+using Parameters
+
+@with_kw mutable struct TSOConfigs
+    cut_conso_penalty = 1e7
+    out_path = nothing
+    problem_name = "TSO"
+end
+
+
+@with_kw struct TSOLimitableModel <: AbstractLimitableModel
+    #gen,ts,s
+    p_injected = SortedDict{Tuple{String,DateTime,String},VariableRef}();
+    #gen,ts,s
+    delta_p = SortedDict{Tuple{String,DateTime,String},VariableRef}();
+    #gen,ts
+    p_limit = SortedDict{Tuple{String,DateTime},VariableRef}();
+    #gen,ts,s
+    b_is_limited = Dict{Tuple{String,DateTime,String},VariableRef}();
+    #gen,ts,s
+    p_limit_x_is_limited = Dict{Tuple{String,DateTime,String},VariableRef}();
+end
+
+@with_kw struct TSOImposableModel <: AbstractImposableModel
+    #gen,ts,s
+    p_injected = SortedDict{Tuple{String,DateTime,String},VariableRef}();
+    #gen,ts,s
+    delta_p = SortedDict{Tuple{String,DateTime,String},VariableRef}();
+    #gen,ts,s
+    b_start = SortedDict{Tuple{String,DateTime,String},VariableRef}();
+    #gen,ts,s
+    b_on = SortedDict{Tuple{String,DateTime,String},VariableRef}();
+    #commitment_constraints = Dict{Tuple{String,DateTime,String},ConstraintRef}();
+    #firmness_constraints
+end
+
+@with_kw struct TSOSlackModel <: AbstractSlackModel
+    #bus,ts,s
+    p_cut_conso = SortedDict{Tuple{String,DateTime,String},VariableRef}();
+end
+
+@with_kw mutable struct TSOObjectiveModel <: AbstractObjectiveModel
+    deltas = AffExpr(0)
+
+    prop_cost = AffExpr(0)
+    start_cost = AffExpr(0)
+
+    penalty = AffExpr(0)
+
+    full_obj_1 = AffExpr(0)
+    full_obj_2 = AffExpr(0)
+end
+
+
+@with_kw mutable struct TSOModel <: AbstractModelContainer
+    model::Model = Model()
+    limitable_model::TSOLimitableModel = TSOLimitableModel()
+    imposable_model::TSOImposableModel = TSOImposableModel()
+    slack_model::TSOSlackModel = TSOSlackModel()
+    objective_model::TSOObjectiveModel = TSOObjectiveModel()
+    #ts,s
+    eod_constraint::SortedDict{Tuple{Dates.DateTime,String}, ConstraintRef} =
+        SortedDict{Tuple{Dates.DateTime,String}, ConstraintRef}()
+    #branch,ts,s
+    flows::SortedDict{Tuple{String,DateTime,String},VariableRef} =
+        SortedDict{Tuple{String,DateTime,String},VariableRef}()
+    status::PSCOPFStatus = pscopf_UNSOLVED
+end
+
+
+function get_p_injected(model_container::TSOModel, type::Networks.GeneratorType)
+    if type == Networks.LIMITABLE
+        return model_container.limitable_model.p_injected
+    elseif type == Networks.IMPOSABLE
+        return model_container.imposable_model.p_injected
+    end
+    return nothing
+end
+
+function add_p_delta!(generator_model::AbstractGeneratorModel, model::Model,
+                        gen_id::String, ts::DateTime, s::String,
+                        p_reference::Float64
+                        )
+    deltas = generator_model.delta_p
+    p_injected = generator_model.p_injected
+
+    name =  @sprintf("Delta_p[%s,%s,%s]", gen_id, ts, s)
+    deltas[gen_id, ts, s] = @variable(model, base_name=name)
+    @constraint(model, deltas[gen_id, ts, s] >= p_injected[gen_id, ts, s] - p_reference)
+    @constraint(model, deltas[gen_id, ts, s] >= p_reference - p_injected[gen_id, ts, s])
+
+    return generator_model.delta_p[gen_id, ts, s]
+end
+
+function add_limitable!(limitable_model::TSOLimitableModel, model::Model,
+                        generator::Networks.Generator,
+                        target_timepoints::Vector{Dates.DateTime},
+                        scenarios::Vector{String},
+                        inject_uncertainties::InjectionUncertainties,
+                        power_level_firmness::SortedDict{Dates.DateTime, DecisionFirmness}, #by ts
+                        preceding_limitations::SortedDict{Tuple{String, Dates.DateTime}, Float64},
+                        preceding_market_subschedule::GeneratorSchedule
+                        )
+    gen_id = Networks.get_id(generator)
+    gen_pmax = Networks.get_p_max(generator)
+    for ts in target_timepoints
+        for s in scenarios
+            p_enr = min(gen_pmax, inject_uncertainties[ts][s]) #FIXME and limit induced by the TSO, potentially (for other markets, this for now does not look at the TSO constraints)
+            add_p_injected!(limitable_model, model, gen_id, ts, s, p_enr, false)
+            add_p_delta!(limitable_model, model, gen_id, ts, s,
+                        get_prod_value(preceding_market_subschedule, ts, s))
+        end
+
+        add_p_limit!(limitable_model, model, gen_id, ts, scenarios, gen_pmax,
+                    inject_uncertainties,
+                    power_level_firmness[ts],
+                    get_limitation(preceding_limitations, gen_id, ts))
+    end
+
+    return limitable_model, model
+end
+
+function add_limitables!(model_container::TSOModel, network::Networks.Network,
+                        target_timepoints::Vector{Dates.DateTime},
+                        scenarios::Vector{String},
+                        uncertainties_at_ech::UncertaintiesAtEch,
+                        firmness::Firmness,
+                        preceding_limitations::SortedDict{Tuple{String, Dates.DateTime}, Float64},
+                        preceding_market_schedule::Schedule
+                        )
+    limitable_model = model_container.limitable_model
+    model = model_container.model
+
+    limitable_generators = Networks.get_generators_of_type(network, Networks.LIMITABLE)
+    for limitable_gen in limitable_generators
+        gen_id = Networks.get_id(limitable_gen)
+        add_limitable!(limitable_model, model,
+                        limitable_gen,
+                        target_timepoints,
+                        scenarios,
+                        get_uncertainties(uncertainties_at_ech, gen_id),
+                        get_power_level_firmness(firmness, gen_id),
+                        preceding_limitations,
+                        get_sub_schedule(preceding_market_schedule, gen_id)
+                        )
+    end
+
+    return model_container.limitable_model
+end
+
+function add_imposable!(imposable_model::TSOImposableModel, model::Model,
+                        generator::Networks.Generator,
+                        target_timepoints::Vector{Dates.DateTime},
+                        scenarios::Vector{String},
+                        generator_initial_state::GeneratorState,
+                        commitment_firmness::Union{Missing,SortedDict{Dates.DateTime, DecisionFirmness}}, #by ts #or Missing
+                        power_level_firmness::SortedDict{Dates.DateTime, DecisionFirmness}, #by ts
+                        preceding_tso_subschedule::GeneratorSchedule,
+                        preceding_market_subschedule::GeneratorSchedule
+                        )
+    gen_id = Networks.get_id(generator)
+    p_min = Networks.get_p_min(generator)
+    p_max = Networks.get_p_max(generator)
+    for ts in target_timepoints
+        for s in scenarios
+            add_p_injected!(imposable_model, model, gen_id, ts, s, p_max, false)
+            add_p_delta!(imposable_model, model, gen_id, ts, s,
+                        get_prod_value(preceding_market_subschedule, ts, s))
+        end
+    end
+
+    add_power_level_firmness_constraints!(model, generator,
+                                        imposable_model.p_injected,
+                                        target_timepoints, scenarios,
+                                        power_level_firmness,
+                                        preceding_tso_subschedule
+                                        )
+
+    if p_min > 0
+        add_commitment!(imposable_model, model, generator,
+                        target_timepoints, scenarios, generator_initial_state
+                        )
+        add_commitment_firmness_constraints!(model, generator,
+                                            imposable_model.b_on,
+                                            imposable_model.b_start,
+                                            target_timepoints, scenarios,
+                                            generator_initial_state,
+                                            commitment_firmness,
+                                            preceding_tso_subschedule
+                                            )
+    end
+
+    return imposable_model, model
+end
+
+function add_imposables!(model_container::TSOModel, network::Networks.Network,
+                        target_timepoints::Vector{Dates.DateTime},
+                        scenarios::Vector{String},
+                        generators_initial_state::SortedDict{String,GeneratorState},
+                        firmness::Firmness,
+                        preceding_tso_schedule::Schedule,
+                        preceding_market_schedule::Schedule
+                        )
+    imposable_generators = Networks.get_generators_of_type(network, Networks.IMPOSABLE)
+    for imposable_gen in imposable_generators
+        gen_id = Networks.get_id(imposable_gen)
+        gen_initial_state = get_initial_state(generators_initial_state, imposable_gen)
+        add_imposable!(model_container.imposable_model, model_container.model,
+                        imposable_gen,
+                        target_timepoints,
+                        scenarios,
+                        gen_initial_state,
+                        get_commitment_firmness(firmness, gen_id),
+                        get_power_level_firmness(firmness, gen_id),
+                        get_sub_schedule(preceding_tso_schedule, gen_id),
+                        get_sub_schedule(preceding_market_schedule, gen_id)
+                        )
+    end
+    return model_container.imposable_model
+end
+
+function add_slacks!(model_container::TSOModel,
+                    network::Networks.Network,
+                    target_timepoints::Vector{Dates.DateTime},
+                    scenarios::Vector{String},
+                    uncertainties_at_ech::UncertaintiesAtEch)
+    model = model_container.model
+    slack_model = model_container.slack_model
+    for ts in target_timepoints
+        for s in scenarios
+            for bus in Networks.get_buses(network)
+                bus_id = Networks.get_id(bus)
+                name =  @sprintf("P_cut_conso[%s,%s,%s]", bus_id, ts, s)
+                load = get_uncertainties(uncertainties_at_ech, bus_id, ts, s)
+                slack_model.p_cut_conso[bus_id, ts, s] = @variable(model, base_name=name,
+                                                            lower_bound=0., upper_bound=load)
+            end
+        end
+    end
+    return model_container.slack_model
+end
+
+function add_eod_constraint!(model_container::TSOModel,
+                            network::Networks.Network,
+                            ts::Dates.DateTime,
+                            scenario::String,
+                            load::Float64)
+    cut_conso = AffExpr(0)
+    for bus in Networks.get_buses(network)
+        bus_id = Networks.get_id(bus)
+        cut_conso += model_container.slack_model.p_cut_conso[bus_id, ts, scenario]
+    end
+
+    prod = ( sum_injections(model_container.limitable_model, ts, scenario) +
+                sum_injections(model_container.imposable_model, ts, scenario) )
+
+    model_container.eod_constraint[ts,scenario] = @constraint(model_container.model,
+                                                    prod == load - cut_conso )
+
+    return model_container
+end
+
+function add_eod_constraints!(model_container::TSOModel,
+                            network::Networks.Network,
+                            target_timepoints::Vector{Dates.DateTime},
+                            scenarios::Vector{String},
+                            uncertainties_at_ech::UncertaintiesAtEch)
+    for ts in target_timepoints
+        for s in scenarios
+            load = compute_load(uncertainties_at_ech, network, ts, s)
+            add_eod_constraint!(model_container, network, ts, s, load)
+        end
+    end
+    return model_container
+end
+
+function add_flows!(model_container::TSOModel,
+                    network::Networks.Network,
+                    target_timepoints::Vector{Dates.DateTime},
+                    scenarios::Vector{String},
+                    uncertainties_at_ech::UncertaintiesAtEch)
+    for branch in Networks.get_branches(network)
+        branch_id = Networks.get_id(branch)
+        for ts in target_timepoints
+            for s in scenarios
+                flow_limit_l = Networks.get_limit(branch)
+                name =  @sprintf("Flow[%s,%s,%s]", branch_id, ts, s)
+                model_container.flows[branch_id, ts, s] =
+                    @variable(model_container.model, base_name=name, lower_bound=-flow_limit_l, upper_bound=flow_limit_l)
+
+                flow_l = AffExpr(0)
+                for bus in Networks.get_buses(network)
+                    bus_id = Networks.get_id(bus)
+                    ptdf = Networks.safeget_ptdf(network, branch_id, bus_id)
+
+                    # + injections
+                    for gen in Networks.get_generators(bus)
+                        gen_id = Networks.get_id(gen)
+                        gen_type = Networks.get_type(gen)
+                        var_p_injected = get_p_injected(model_container, gen_type)[gen_id, ts, s]
+                        flow_l += ptdf * var_p_injected
+                    end
+
+                    # - loads
+                    flow_l -= ptdf * get_uncertainties(uncertainties_at_ech, bus_id, ts, s)
+
+                    # + cutting loads ~ injections
+                    flow_l += ptdf * model_container.slack_model.p_cut_conso[bus_id, ts, s]
+                end
+                @constraint(model_container.model, model_container.flows[branch_id, ts, s] == flow_l )
+            end
+        end
+    end
+    return model_container
+end
+
+function create_objective!(model_container::TSOModel, network, gratis_starts, cut_conso_cost)
+    # cost for cutting load/consumption
+    for ((_,_), p_cut_conso) in model_container.slack_model.p_cut_conso
+        model_container.objective_model.penalty += cut_conso_cost * p_cut_conso
+    end
+    # avoid limiting when not necessary
+    for (_, var_is_limited) in model_container.limitable_model.b_is_limited
+        model_container.objective_model.penalty += 1e-03 * var_is_limited
+    end
+
+    # cost for deviating from market schedule
+    for (_, var_delta) in model_container.imposable_model.delta_p
+        model_container.objective_model.deltas += var_delta
+    end
+
+    model_container.objective_model.full_obj_1 = ( model_container.objective_model.deltas +
+                                                model_container.objective_model.penalty )
+
+    return model_container
+end
+
+function solve!(model_container::TSOModel, problem_name, out_path)
+    model = get_model(model_container)
+
+    @objective(model, Min, model_container.objective_model.full_obj_1)
+
+    solve!(model, problem_name, out_path)
+end
+
+function tso_out_fo(network::Networks.Network,
+                    target_timepoints::Vector{Dates.DateTime},
+                    generators_initial_state::SortedDict{String,GeneratorState},
+                    scenarios::Vector{String},
+                    uncertainties_at_ech::UncertaintiesAtEch,
+                    firmness::Firmness,
+                    preceding_market_schedule::Schedule,
+                    preceding_tso_schedule::Schedule,
+                    preceding_tso_actions::TSOActions,
+                    gratis_starts::Set{Tuple{String,Dates.DateTime}},
+                    configs::TSOConfigs
+                    )
+
+    model_container_l = TSOModel()
+
+    add_limitables!(model_container_l,
+                    network, target_timepoints,
+                    scenarios,
+                    uncertainties_at_ech,
+                    firmness,
+                    get_limitations(preceding_tso_actions),
+                    preceding_market_schedule
+                    )
+
+    # TODO : check coherence between : preceding_tso_schedule and TSOActions.impositions
+    add_imposables!(model_container_l,
+                    network, target_timepoints,
+                    scenarios,
+                    generators_initial_state,
+                    firmness,
+                    preceding_tso_schedule,
+                    preceding_market_schedule)
+
+    add_slacks!(model_container_l,
+                network, target_timepoints, scenarios,
+                uncertainties_at_ech)
+
+    add_eod_constraints!(model_container_l,
+                        network, target_timepoints, scenarios,
+                        uncertainties_at_ech
+                        )
+
+    add_flows!(model_container_l,
+                        network, target_timepoints, scenarios,
+                        uncertainties_at_ech
+                        )
+
+    create_objective!(model_container_l, network, gratis_starts, configs.cut_conso_penalty)
+
+    solve!(model_container_l, configs.problem_name, configs.out_path)
+
+    status_l = get_status(model_container_l)
+
+    @info "pscopf model status: $status_l"
+    @info "Termination status : $(termination_status(model_container_l.model))"
+    @info "Objective value : $(objective_value(model_container_l.model))"
+
+    return model_container_l
+end

--- a/src/steps/tso_impl.jl
+++ b/src/steps/tso_impl.jl
@@ -212,6 +212,7 @@ function add_imposables!(model_container::TSOModel, network::Networks.Network,
     for imposable_gen in imposable_generators
         gen_id = Networks.get_id(imposable_gen)
         gen_initial_state = get_initial_state(generators_initial_state, imposable_gen)
+        println("IMPOSABLE: ", gen_id)
         add_imposable!(model_container.imposable_model, model_container.model,
                         imposable_gen,
                         target_timepoints,
@@ -336,6 +337,9 @@ function create_objectives!(model_container::TSOModel, network, gratis_starts, c
 
     # cost for deviating from market schedule
     for (_, var_delta) in model_container.imposable_model.delta_p
+        model_container.objective_model.deltas += var_delta
+    end
+    for (_, var_delta) in model_container.limitable_model.delta_p
         model_container.objective_model.deltas += var_delta
     end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -80,13 +80,21 @@ function pretty_print(io::IO, d::AbstractDict; spacing=1, sort_p::Bool=false)
     nothing
 end
 
-function rm_non_prefixed(dir::String, prefix::String)
+function rm_files(dir::String, f)
     if isdir(dir)
-        non_prefixed = filter(!startswith(prefix), readdir(dir))
-        paths = joinpath.(dir, non_prefixed)
+        matches = filter(f, readdir(dir))
+        paths = joinpath.(dir, matches)
         files_to_rm = filter(isfile, paths)
         foreach(rm, files_to_rm)
     end
+end
+
+function rm_non_prefixed(dir::String, prefix::String)
+    rm_files(dir, !startswith(prefix))
+end
+
+function rm_prefixed(dir::String, prefix::String)
+    rm_files(dir, startswith(prefix))
 end
 
 function split_with_space(str::String)

--- a/src_mains/main_ptdf.jl
+++ b/src_mains/main_ptdf.jl
@@ -23,10 +23,19 @@ include(joinpath(root_path, "src", "PTDF.jl"));
 
 input_path = ( length(ARGS) > 0 ? ARGS[1] :
                     joinpath(@__DIR__, "..", "data", "ptdf") )
-
+output_path = joinpath(input_path, "pscopf_ptdf.txt")
+ref_bus_num = 1
+distributed = true
 
 #########################
 # EXECUTION
 #########################
-ref_bus_num = 1
-PTDF.compute_ptdf(input_path, ref_bus_num)
+network = PTDF.read_network(input_path)
+ptdf = PTDF.compute_ptdf(network, ref_bus_num)
+if distributed
+    ptdf = PTDF.distribute_slack(ptdf);
+    # coeffs = Dict([ "poste_1_0" => .2,
+    #                 "poste_2_0" => .8])
+    # ptdf = PTDF.distribute_slack(ptdf, coeffs, network);
+end
+PTDF.write_PTDF(output_path, network, ptdf, distributed, ref_bus_num)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ using PSCOPF
     include("test_wip/test_models/tso_out_fo/test_dp_limitable.jl")
     include("test_wip/test_models/tso_out_fo/test_dmo.jl")
     include("test_wip/test_models/tso_out_fo/test_constraints.jl")
+    include("test_wip/test_models/tso_out_fo/test_slacks.jl")
 
     # include("test_wip/test_seq_launch.jl")
     include("test_wip/example_usecase.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,4 @@
 using Test
-using Dates: Date, DateTime;
-using DataStructures
-import Logging
 
 using PSCOPF
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,12 @@ using PSCOPF
     include("test_wip/test_models/energy_market/test_slacks.jl")
     include("test_wip/test_models/energy_market/test_energy_market_at_fo.jl")
 
+    include("test_wip/test_models/tso_out_fo/test_tso.jl")
+    include("test_wip/test_models/tso_out_fo/test_dp_imposable.jl")
+    include("test_wip/test_models/tso_out_fo/test_dp_limitable.jl")
+    include("test_wip/test_models/tso_out_fo/test_dmo.jl")
+    include("test_wip/test_models/tso_out_fo/test_constraints.jl")
+
     # include("test_wip/test_seq_launch.jl")
     include("test_wip/example_usecase.jl")
     include("test_wip/example_usecase_from_folder.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ using PSCOPF
     include("test_wip/test_models/energy_market/test_start_cost.jl")
     include("test_wip/test_models/energy_market/test_dmo.jl")
     include("test_wip/test_models/energy_market/test_dp.jl")
+    include("test_wip/test_models/energy_market/test_slacks.jl")
     include("test_wip/test_models/energy_market/test_energy_market_at_fo.jl")
 
     # include("test_wip/test_seq_launch.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,8 @@ using PSCOPF
     include("test_wip/test_models/tso_out_fo/test_dmo.jl")
     include("test_wip/test_models/tso_out_fo/test_constraints.jl")
     include("test_wip/test_models/tso_out_fo/test_slacks.jl")
+    include("test_wip/test_models/tso_out_fo/test_start_cost.jl")
+    include("test_wip/test_models/tso_out_fo/test_unit_priority.jl")
 
     # include("test_wip/test_seq_launch.jl")
     include("test_wip/example_usecase.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,7 @@ using PSCOPF
     include("test_wip/test_models/tso_out_fo/test_slacks.jl")
     include("test_wip/test_models/tso_out_fo/test_start_cost.jl")
     include("test_wip/test_models/tso_out_fo/test_unit_priority.jl")
+    include("test_wip/test_models/tso_out_fo/test_limitation.jl")
 
     # include("test_wip/test_seq_launch.jl")
     include("test_wip/example_usecase.jl")

--- a/test/test_wip/test_coherence_checks/test_check_initial_state.jl
+++ b/test/test_wip/test_coherence_checks/test_check_initial_state.jl
@@ -2,6 +2,7 @@ using PSCOPF
 
 using Test
 using Dates
+using DataStructures
 
 @testset "test_check_initial_state" begin
 

--- a/test/test_wip/test_coherence_checks/test_check_ptdf.jl
+++ b/test/test_wip/test_coherence_checks/test_check_ptdf.jl
@@ -1,7 +1,7 @@
 using PSCOPF
 
 using Test
-using Dates
+using DataStructures
 
 @testset "test_check_ptdf" begin
 

--- a/test/test_wip/test_coherence_checks/test_check_uncertainties.jl
+++ b/test/test_wip/test_coherence_checks/test_check_uncertainties.jl
@@ -2,6 +2,7 @@ using PSCOPF
 
 using Test
 using Dates
+using DataStructures
 
 @testset "test_check_TS" begin
 

--- a/test/test_wip/test_custom_sequence.jl
+++ b/test/test_wip/test_custom_sequence.jl
@@ -48,7 +48,7 @@ using DataStructures
             push!(schedule_history, deepcopy(tso_schedule))
         end
         #affects_tso_actions_schedule default to true cause <:AbstractTSO
-        function PSCOPF.update_tso_actions!(tso_actions, ech, result, firmness, runnable::MockTSO)
+        function PSCOPF.update_tso_actions!(context::PSCOPF.AbstractContext, ech, result, firmness, runnable::MockTSO)
             nothing
         end
 

--- a/test/test_wip/test_models/energy_market/test_constraints.jl
+++ b/test/test_wip/test_models/energy_market/test_constraints.jl
@@ -135,7 +135,7 @@ using Printf
                                         PSCOPF.get_network(context),
                                         ech, ts, s)
                 @printf("ts:%s, s:%s : %f\n", ts, s, flow)
-                @test ( (flow > 35.) || (flow < -35.) ) #the branch limit
+                @test !( -35. < flow < 35. ) #flow exceeds branch limit
             end
         end
     end

--- a/test/test_wip/test_models/energy_market/test_constraints.jl
+++ b/test/test_wip/test_models/energy_market/test_constraints.jl
@@ -1,7 +1,9 @@
 using PSCOPF
 
 using Test
+using JuMP
 using Dates
+using DataStructures
 using Printf
 
 @testset verbose=true "test_energy_market_constraints" begin
@@ -126,7 +128,9 @@ using Printf
     @testset "energy_market_does_not_consider_RSO_constraints" begin
         # Solution is optimal
         @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+
         # But, RSO constraints are not satisfied:
+        # Note : compute_flow does not consider cut_conso (valid here cause cut_conso=0, proven by pscopf_OPTIMAL)
         for ts in TS
             for s in ["S1", "S2"]
                 flow = PSCOPF.compute_flow("branch_1_2",
@@ -135,7 +139,7 @@ using Printf
                                         PSCOPF.get_network(context),
                                         ech, ts, s)
                 @printf("ts:%s, s:%s : %f\n", ts, s, flow)
-                @test !( -35. < flow < 35. ) #flow exceeds branch limit
+                @test !( -35. <= flow <= 35. ) #flow exceeds branch limit
             end
         end
     end

--- a/test/test_wip/test_models/energy_market/test_dmo.jl
+++ b/test/test_wip/test_models/energy_market/test_dmo.jl
@@ -1,7 +1,9 @@
 using PSCOPF
 
 using Test
+using JuMP
 using Dates
+using DataStructures
 
 @testset verbose=true "test_energy_market_dmo" begin
 

--- a/test/test_wip/test_models/energy_market/test_dmo.jl
+++ b/test/test_wip/test_models/energy_market/test_dmo.jl
@@ -8,35 +8,31 @@ using Dates
     #=
     TS: [11h]
     S: [S1]
-                        bus 1                   bus 2
-                        |                      |
-    (limitable) wind_1_1|       "1_2"          |
-    Pmin=0, Pmax=100    |                      |
-    Csta=0, Cprop=1     |                      |
-      S1: 20            |----------------------|
-                        |         35           |
-                        |                      |
-                        |                      |
-    (imposable) prod_1_1|                      |(imposable) prod_2_1
-    Pmin=10, Pmax=100   |                      | Pmin=10, Pmax=100
-    Csta=0, Cprop=10    |                      | Csta=0, Cprop=15
-    DMO => 8h           |                      | DMO => 10h30
-                        |                      |
-                load_1  |                      |load_2
-                 S1: 15 |                      | S1: 40
-                        |                      |
+                        bus 1
+                        |
+    (limitable) wind_1_1|load
+    Pmin=0, Pmax=100    |  S1:55
+    Csta=0, Cprop=1     |
+      S1: 20            |
+                        |
+                        |
+                        |
+    (imposable) prod_1_1|
+    Pmin=10, Pmax=100   |
+    Csta=0, Cprop=10    |
+    DMO => 8h           |
+                        |
+    (imposable) prod_1_2|
+     Pmin=10, Pmax=100  |
+     Csta=0, Cprop=15   |
+     DMO => 10h30       |
+                        |
     =#
 
     TS = [DateTime("2015-01-01T11:00:00")]
     network = PSCOPF.Networks.Network()
     # Buses
     PSCOPF.Networks.add_new_bus!(network, "bus_1")
-    PSCOPF.Networks.add_new_bus!(network, "bus_2")
-    # Branches
-    PSCOPF.Networks.add_new_branch!(network, "branch_1_2", 35.);
-    # PTDF
-    PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_1", 0.5)
-    PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_2", -0.5)
     # Limitables
     PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
                                             0., 100.,
@@ -47,29 +43,27 @@ using Dates
                                             10., 100.,
                                             0., 10.,
                                             Dates.Second(3*60*60), Dates.Second(0))
-    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_2", "prod_2_1", PSCOPF.Networks.IMPOSABLE,
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_2", PSCOPF.Networks.IMPOSABLE,
                                             10., 100.,
                                             0., 15.,
                                             Dates.Second(30*60), Dates.Second(0))
     # Uncertainties
     uncertainties = PSCOPF.Uncertainties()
     PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T07:00:00"), "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
-    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T07:00:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
-    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T07:00:00"), "bus_2", DateTime("2015-01-01T11:00:00"), "S1", 40.)
+    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T07:00:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
     PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T09:00:00"), "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
-    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T09:00:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
-    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T09:00:00"), "bus_2", DateTime("2015-01-01T11:00:00"), "S1", 40.)
+    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T09:00:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
     # initial generators state : need to pay starting cost at TS[1]
     generators_init_state = SortedDict(
         "prod_1_1" => PSCOPF.OFF,
-        "prod_2_1" => PSCOPF.OFF
+        "prod_1_2" => PSCOPF.OFF
     )
 
-    # before DMO + still have an ech to decide on => commitment firmness is FRE
+    # before DMO + still have an ech to decide on => commitment firmness is FREE
     @testset "energy_market_can_start_unit_when_commitment_firmness_is_FREE" begin
         ech = DateTime("2015-01-01T07:00:00")
 
-        #For some reason, Initial schedule starts prod_2_1 (prod_1_1 is off) : decisions are not definitive
+        #For some reason, Initial schedule starts prod_1_2 (prod_1_1 is off) : decisions are not definitive
         initial_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
             "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
                 SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
@@ -84,7 +78,7 @@ using Dates
                 SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
                                                                                         SortedDict("S1"=>0.)))
                 ),
-            "prod_2_1" => PSCOPF.GeneratorSchedule("prod_2_1",
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
                 SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
                                                                                         SortedDict("S1"=>PSCOPF.ON))),
                 SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
@@ -94,16 +88,13 @@ using Dates
         )
 
         # firmness
-        # firmness = PSCOPF.Firmness(
-        #         SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-        #                     "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), ),
-        #         SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-        #                     "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-        #                     "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
-        #         )
-        firmness = PSCOPF.compute_firmness(ech, #7h
-                                        DateTime("2015-01-01T08:00:00"), # corresponds to ECH-DMO
-                                        TS, collect(PSCOPF.Networks.get_generators(network)))
+        expected_firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), ),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
 
         context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
                                         generators_init_state,
@@ -113,6 +104,12 @@ using Dates
         context.market_schedule = initial_schedule
 
         market = PSCOPF.EnergyMarket()
+
+        firmness = PSCOPF.compute_firmness(market, ech, #7h
+                                            DateTime("2015-01-01T08:00:00"), # corresponds to ECH-DMO
+                                            TS, context)
+        @test firmness == expected_firmness
+
         result = PSCOPF.run(market, ech, firmness,
                     PSCOPF.get_target_timepoints(context),
                     context)
@@ -124,16 +121,16 @@ using Dates
         # we started prod_1_1
         @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_1", TS[1], "S1")
         @test 35. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
-        # we shut down prod_2_1
-        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.market_schedule, "prod_2_1", TS[1], "S1")
-        @test PSCOPF.get_prod_value(context.market_schedule, "prod_2_1", TS[1], "S1") < 1e-09
+        # we shut down prod_1_2
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_2", TS[1], "S1") < 1e-09
     end
 
     # after DMO => commitment firmness is DECIDED
     @testset "energy_market_cannot_start_unit_when_commitment_firmness_is_DECIDED" begin
         ech = DateTime("2015-01-01T09:00:00")
 
-        #For some reason, Initial schedule starts prod_2_1 (prod_1_1 is off) : decisions are not definitive
+        #For some reason, Initial schedule starts prod_1_2 (prod_1_1 is off) : decisions are not definitive
         initial_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
             "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
                 SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
@@ -148,7 +145,7 @@ using Dates
                 SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
                                                                                         SortedDict("S1"=>0.)))
                 ),
-            "prod_2_1" => PSCOPF.GeneratorSchedule("prod_2_1",
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
                 SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
                                                                                         SortedDict("S1"=>PSCOPF.ON))),
                 SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
@@ -158,16 +155,14 @@ using Dates
         )
 
         # firmness : prod_1_1 is already decided (DMO > ECH)
-        # firmness = PSCOPF.Firmness(
-        #         SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
-        #                     "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), ),
-        #         SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-        #                     "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-        #                     "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
-        #         )
-        firmness = PSCOPF.compute_firmness(ech, #9h
-                                        DateTime("2015-01-01T10:30:00"), # corresponds to ECH-DMO
-                                        TS, collect(PSCOPF.Networks.get_generators(network)))
+        expected_firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), ),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
 
         context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
                                         generators_init_state,
@@ -177,6 +172,12 @@ using Dates
         context.market_schedule = initial_schedule
 
         market = PSCOPF.EnergyMarket()
+
+        firmness = PSCOPF.compute_firmness(market, ech, #9h
+                                            DateTime("2015-01-01T10:30:00"), # corresponds to ECH-DMO
+                                            TS, context)
+        @test firmness == expected_firmness
+
         result = PSCOPF.run(market, ech, firmness,
                     PSCOPF.get_target_timepoints(context),
                     context)
@@ -188,9 +189,9 @@ using Dates
         # we could not start prod_1_1 due to DMO
         @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_1", TS[1], "S1")
         @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1") < 1e-09
-        # we use prod_2_1
-        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_2_1", TS[1], "S1")
-        @test 35. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_2_1", TS[1], "S1")
+        # we use prod_1_2
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S1")
+        @test 35. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_2", TS[1], "S1")
     end
 
 end

--- a/test/test_wip/test_models/energy_market/test_dp.jl
+++ b/test/test_wip/test_models/energy_market/test_dp.jl
@@ -1,7 +1,9 @@
 using PSCOPF
 
 using Test
+using JuMP
 using Dates
+using DataStructures
 
 @testset verbose=true "test_energy_market_dp" begin
 

--- a/test/test_wip/test_models/energy_market/test_dp.jl
+++ b/test/test_wip/test_models/energy_market/test_dp.jl
@@ -8,78 +8,80 @@ using Dates
     #=
     TS: [11h]
     S: [S1]
-                        bus 1                   bus 2
-                        |                      |
-    (limitable) wind_1_1|       "1_2"          |
-    Pmin=0, Pmax=100    |                      |
-    Csta=0, Cprop=1     |                      |
-      S1: 20            |----------------------|
-                        |         35           |
-                        |                      |
-                        |                      |
-    (imposable) prod_1_1|                      |(imposable) prod_2_1
-    Pmin=10, Pmax=100   |                      | Pmin=10, Pmax=100
-    Csta=0, Cprop=10    |                      | Csta=0, Cprop=15
-    DP => 10h30         |                      | DP => 10h45
-                        |                      |
-                load_1  |                      |load_2
-                 S1: 15 |                      | S1: 40
-                        |                      |
+                        bus 1
+                        |
+    (limitable) wind_1_1|load
+    Pmin=0, Pmax=100    | S1: 55
+    Csta=0, Cprop=1     |
+    DP => 10h45         |
+      S1: 20            |
+                        |
+    (imposable) prod_1_1|
+    Pmin=10, Pmax=100   |
+    Csta=0, Cprop=10    |
+    DP => 10h30         |
+                        |
+    (imposable) prod_1_2|
+     Pmin=10, Pmax=100  |
+     Csta=0, Cprop=15   |
+     DP => 10h45        |
+                        |
+
     =#
 
     TS = [DateTime("2015-01-01T11:00:00")]
     network = PSCOPF.Networks.Network()
     # Buses
     PSCOPF.Networks.add_new_bus!(network, "bus_1")
-    PSCOPF.Networks.add_new_bus!(network, "bus_2")
-    # Branches
-    PSCOPF.Networks.add_new_branch!(network, "branch_1_2", 500.);
-    # PTDF
-    PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_1", 0.5)
-    PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_2", -0.5)
     # Limitables
     PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
                                             0., 100.,
                                             0., 1.,
-                                            Dates.Second(0), Dates.Second(0))
+                                            Dates.Second(20*60), Dates.Second(20*60))
     # Imposables
     PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
                                             10., 100.,
                                             0., 10.,
                                             Dates.Second(3*60*60), Dates.Second(30*60))
-    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_2", "prod_2_1", PSCOPF.Networks.IMPOSABLE,
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_2", PSCOPF.Networks.IMPOSABLE,
                                             10., 100.,
                                             0., 15.,
                                             Dates.Second(3*60*60), Dates.Second(15*60))
     # Uncertainties
     uncertainties = PSCOPF.Uncertainties()
     PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:00:00"), "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
-    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:00:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
-    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:00:00"), "bus_2", DateTime("2015-01-01T11:00:00"), "S1", 40.)
+    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:00:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
     PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:40:00"), "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
-    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:40:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
-    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:40:00"), "bus_2", DateTime("2015-01-01T11:00:00"), "S1", 40.)
+    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:40:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
     # initial generators state : need to pay starting cost at TS[1]
     generators_init_state = SortedDict(
         "prod_1_1" => PSCOPF.OFF,
-        "prod_2_1" => PSCOPF.OFF
+        "prod_1_2" => PSCOPF.OFF
     )
     #ManagementMode
     mode = PSCOPF.ManagementMode("test_mode", Dates.Minute(5))
 
+    #=
+            ECH   TS
+    |        |    |
+            10h   11h
+             <---->
+               FO
+    =#
     @testset "energy_market_cannot_be_launched_after_or_at_FO" begin
         ech = DateTime("2015-01-01T10:00:00")
+        mode1 = PSCOPF.PSCOPF_MODE_1 # FO == 10h
 
         # firmness : wrong firmness % ech/DMO/DP but doesn't matter
         firmness = PSCOPF.Firmness(
                 SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), ),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), ),
                 SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
                             "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
                 )
 
-        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1, # FO == 10h
+        context = PSCOPF.PSCOPFContext(network, TS, mode1,
                                         generators_init_state,
                                         uncertainties, nothing)
 
@@ -90,23 +92,31 @@ using Dates
     end
 
 
+    #=
+    ECH1*         ECH2            ECH3                                 <---FO--->TS
+    |             |               |
+    10h           10h30           10h40          10h45                          11h
+                  <------------------------------------------DP(prod1)----------->
+                                  <--------------------------DP(wind1)----------->
+                                                   <---------DP(prod2)----------->
+    =#
     @testset "energy_market_can_change_the_production_level_before_dp" begin
         ech = DateTime("2015-01-01T10:00:00")
 
         # firmness
         firmness = PSCOPF.Firmness(
                 SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
-                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
                 SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
                             "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
                 )
 
         context = PSCOPF.PSCOPFContext(network, TS, mode,
                                         generators_init_state,
                                         uncertainties, nothing)
 
-        # prod_1_1 and prod_2_1 are both ON (e.g. due to RSO constraint)
+        # prod_1_1 and prod_1_2 are both ON (e.g. due to RSO constraint)
         context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
                                         "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
                                             SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
@@ -121,7 +131,7 @@ using Dates
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
                                                                                                                     SortedDict("S1"=>17.)))
                                             ),
-                                        "prod_2_1" => PSCOPF.GeneratorSchedule("prod_2_1",
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
                                                                                                                     SortedDict("S1"=>PSCOPF.ON))),
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
@@ -131,6 +141,11 @@ using Dates
                                 )
 
         market = PSCOPF.EnergyMarket()
+
+        @test firmness == PSCOPF.compute_firmness(market,
+                                                ech, DateTime("2015-01-01T10:30:00"),
+                                                TS, context)
+
         result = PSCOPF.run(market, ech, firmness,
                     PSCOPF.get_target_timepoints(context),
                     context)
@@ -143,12 +158,20 @@ using Dates
         # prod_1_1 : 17 => 25.
         @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_1", TS[1], "S1")
         @test 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
-        # prod_2_1 : 20 => 10.
-        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_2_1", TS[1], "S1")
-        @test 10. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_2_1", TS[1], "S1")
+        # prod_1_2 : 20 => 10.
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S1")
+        @test 10. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_2", TS[1], "S1")
     end
 
 
+    #=
+    ECH1          ECH2            ECH3*          ECH4                  <---FO--->TS
+    |             |               |
+    10h           10h30           10h40          10h45                          11h
+                  <------------------------------------------DP(prod1)----------->
+                                  <--------------------------DP(wind1)----------->
+                                                   <---------DP(prod2)----------->
+    =#
     @testset "energy_market_cannot_change_the_production_level_after_dp" begin
         # We are past DP[prod_1_1]
         ech = DateTime("2015-01-01T10:40:00")
@@ -156,17 +179,17 @@ using Dates
         # firmness
         firmness = PSCOPF.Firmness(
                 SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
-                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
-                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.TO_DECIDE),
                             "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
-                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
                 )
 
         context = PSCOPF.PSCOPFContext(network, TS, mode,
                                         generators_init_state,
                                         uncertainties, nothing)
 
-        # prod_1_1 and prod_2_1 are both ON (e.g. due to RSO constraint)
+        # prod_1_1 and prod_1_2 are both ON (e.g. due to RSO constraint)
         # prod_1_1 has a definitive value since we are past the DP
         context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
                                         "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
@@ -182,7 +205,7 @@ using Dates
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(17.,
                                                                                                                     SortedDict("S1"=>17.)))
                                             ),
-                                        "prod_2_1" => PSCOPF.GeneratorSchedule("prod_2_1",
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
                                                                                                                     SortedDict("S1"=>PSCOPF.ON))),
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
@@ -192,6 +215,11 @@ using Dates
                                 )
 
         market = PSCOPF.EnergyMarket()
+
+        @test firmness == PSCOPF.compute_firmness(market,
+                                                ech, DateTime("2015-01-01T10:45:00"),
+                                                TS, context)
+
         result = PSCOPF.run(market, ech, firmness,
                     PSCOPF.get_target_timepoints(context),
                     context)
@@ -204,21 +232,99 @@ using Dates
         # prod_1_1 : 17.
         @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_1", TS[1], "S1")
         @test 17. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
-        # prod_2_1 : 20 => 18.
-        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_2_1", TS[1], "S1")
-        @test 18. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_2_1", TS[1], "S1")
+        # prod_1_2 : 20 => 18.
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S1")
+        @test 18. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_2", TS[1], "S1")
     end
 
+    #=
+    at ECH2, we are at wind_1_1's DP,
+    but the decision made will still be by scenario cause it depends on the uncertainties
+    limitables's DP only applies to limitation decisions (=> applied in TSO)
+    ECH1          ECH2            ECH3*          ECH4                  <---FO--->TS
+    |             |               |
+    10h           10h30           10h40          10h45                          11h
+                  <------------------------------------------DP(prod1)----------->
+                                  <--------------------------DP(wind1)----------->
+                                                   <---------DP(prod2)----------->
+    =#
+    @testset "energy_market_wind_is_always_uncertain" begin
+        # We are past DP[prod_1_1]
+        ech = DateTime("2015-01-01T10:40:00")
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.TO_DECIDE),
+                            "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        # prod_1_1 and prod_1_2 are both ON (e.g. due to RSO constraint)
+        # prod_1_1 has a definitive value since we are past the DP
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
+                                        "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                                            SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                                            # SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                            #                                                                         SortedDict("S1"=>PSCOPF.ON))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>18.)))
+                                            ),
+                                        "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(17.,
+                                                                                                                    SortedDict("S1"=>17.)))
+                                            ),
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>20.)))
+                                            )
+                                        )
+                                )
+
+        market = PSCOPF.EnergyMarket()
+
+        @test firmness == PSCOPF.compute_firmness(market,
+                                                ech, DateTime("2015-01-01T10:45:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(market, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test 20. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1")
+        @test !PSCOPF.is_definitive(PSCOPF.get_prod_uncertain_value(context.market_schedule, "wind_1_1", TS[1]))
+    end
+
+    #=
+    ECH1*         ECH2            ECH3           ECH4                  <---FO--->TS
+    |             |               |
+    10h           10h30           10h40          10h45                          11h
+                  <------------------------------------------DP(prod1)----------->
+                                  <--------------------------DP(wind1)----------->
+                                                   <---------DP(prod2)----------->
+    =#
     @testset "energy_market_cannot_change_the_production_level_before_dp_if_unit_is_off_and_past_DMO" begin
         ech = DateTime("2015-01-01T10:00:00")
 
         # firmness
         firmness = PSCOPF.Firmness(
                 SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
-                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
                 SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
                             "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
                 )
 
         context = PSCOPF.PSCOPFContext(network, TS, mode,
@@ -240,7 +346,7 @@ using Dates
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
                                                                                                                     SortedDict("S1"=>0.)))
                                             ),
-                                        "prod_2_1" => PSCOPF.GeneratorSchedule("prod_2_1",
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
                                                                                                                     SortedDict("S1"=>PSCOPF.ON))),
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
@@ -250,6 +356,11 @@ using Dates
                                 )
 
         market = PSCOPF.EnergyMarket()
+
+        @test firmness == PSCOPF.compute_firmness(market,
+                                                ech, DateTime("2015-01-01T10:30:00"),
+                                                TS, context)
+
         result = PSCOPF.run(market, ech, firmness,
                     PSCOPF.get_target_timepoints(context),
                     context)
@@ -262,9 +373,9 @@ using Dates
         # prod_1_1 : OFF
         @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_1", TS[1], "S1")
         @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1") < 1e-09
-        # prod_2_1 : 25 => 35.
-        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_2_1", TS[1], "S1")
-        @test 35. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_2_1", TS[1], "S1")
+        # prod_1_2 : 25 => 35.
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S1")
+        @test 35. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_2", TS[1], "S1")
     end
 
 end

--- a/test/test_wip/test_models/energy_market/test_energy_market_at_fo.jl
+++ b/test/test_wip/test_models/energy_market/test_energy_market_at_fo.jl
@@ -1,8 +1,9 @@
 using PSCOPF
 
 using Test
+using JuMP
 using Dates
-using Printf
+using DataStructures
 
 @testset verbose=true "test_energy_market_at_fo" begin
 

--- a/test/test_wip/test_models/energy_market/test_slacks.jl
+++ b/test/test_wip/test_models/energy_market/test_slacks.jl
@@ -119,7 +119,7 @@ using JuMP
                                         generators_init_state,
                                         uncertainties, nothing)
         market = PSCOPF.EnergyMarket()
-        market.configs.force_limitables_to_uncertainty = false
+        market.configs.force_limitables = false
         result = PSCOPF.run(market, ech, firmness,
                     PSCOPF.get_target_timepoints(context),
                     context)
@@ -336,5 +336,8 @@ using JuMP
         @test 5. ≈ value(result.limitable_model.p_capping[TS[1], "S2"])
         @test value(result.slack_model.p_cut_conso[TS[1], "S2"]) < 1e-09
     end
+
+
+    #TODO : illustrate slack effect
 
 end

--- a/test/test_wip/test_models/energy_market/test_slacks.jl
+++ b/test/test_wip/test_models/energy_market/test_slacks.jl
@@ -187,7 +187,7 @@ using DataStructures
                     context)
         PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
 
-        # TODO a status to indicate using slacks for feasibility
+        # indicates using slacks for feasibility
         @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         # S1 : prod_capacity < load => cannot satisfy demand
         @test 100. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
@@ -258,10 +258,10 @@ using DataStructures
         PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
 
         # Desired Solution
-        @test_broken PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
-        @test_broken 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
-        @test_broken value(result.slack_model.p_cut_conso[TS[1], "S1"]) < 1e-09
-        @test_broken value(result.objective_model.penalty) < 1e-09
+        @test !( PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL )
+        @test !( 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1") )
+        @test !( value(result.slack_model.p_cut_conso[TS[1], "S1"]) < 1e-09 )
+        @test !( value(result.objective_model.penalty) < 1e-09 )
 
         # retrieved solution
         @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
@@ -326,7 +326,7 @@ using DataStructures
                     context)
         PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
 
-        # TODO a status to indicate using slacks for feasibility because of scenario S1
+        # indicates using slacks for feasibility because of scenario S1
         @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
 
         # In S1 : Load=15, wind provides 10 => still missing 5 but pmin=20
@@ -344,7 +344,165 @@ using DataStructures
         @test value(result.slack_model.p_cut_conso[TS[1], "S2"]) < 1e-09
     end
 
+    #=
+    For now,
+     capped power is distributed evenly (in terms of percentage of available power)
+     among the limitable generators
+    TODO? base ratio on prop_cost ? in that case, careful for null and negative prop_cost
 
-    #TODO : illustrate slack effect
+    TS: [11h]
+    S: [S1]
+                      bus 1
+                        |
+    (limitable) wind_1_1|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=1     |     load_1
+      S1: 50            | S1: 15
+                        |
+    (limitable) wind_1_2|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=2     |
+      S1: 10            |
+                        |
+    (limitable) wind_1_3|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=1     |
+      S1: 0             |
+    =#
+    @testset "energy_market_capping_distribution_in_schedule" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_2", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 2.,
+                                                Dates.Second(0), Dates.Second(0))
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_3", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 50.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_2", DateTime("2015-01-01T11:00:00"), "S1", 10.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_3", DateTime("2015-01-01T11:00:00"), "S1", 0.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict{String, SortedDict{Dates.DateTime, PSCOPF.DecisionFirmness} }(),
+                    SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                                "wind_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                                "wind_1_3" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE)),
+                    )
+        # initial generators state : No need because all pmin=0 => ON by default
+        generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        market = PSCOPF.EnergyMarket()
+        result = PSCOPF.run(market, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # Limitable produces to the available level
+        @test 50. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1")
+        @test 10. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_2", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.market_schedule, "wind_1_3", TS[1], "S1") <= 1e-09
+
+        # Total capped power
+        @test 45. ≈ value(result.limitable_model.p_capping[TS[1], "S1"])
+
+        # Capping distributed
+        @test 0.75 ≈ 45 / 60
+        @test (0.75 * 50)  ≈ context.market_schedule.capping["wind_1_1", TS[1], "S1"]
+        @test (0.75 * 10.) ≈ context.market_schedule.capping["wind_1_2", TS[1], "S1"]
+        @test (0.75 * 0.)  ≈ context.market_schedule.capping["wind_1_3", TS[1], "S1"]
+    end
+
+    #=
+    TS: [11h, 11h15]
+    S: [S1,S2]
+                        bus 1                   bus 2
+                        |                      |
+    (limitable) wind_1_1|       "1_2"          |
+    Pmin=0, Pmax=200    |                      |
+    Csta=0, Cprop=1     |                      |
+      S1: 160           |----------------------|
+                        |         5            |
+                        |                      |
+    load                |                      |load
+      S1: 180           |                      |  S1: 20
+
+    available prod : 160
+    total load : 200
+    => need to cut 40 => 20% of load
+    cut 20% on each bus :
+        bus1: 20% of 180 => 36
+        bus2: 20% of 20  => 4
+    =#
+    @testset "energy_market_cutting_load_distribution_by_bus_in_schedule" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        # Buses
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        PSCOPF.Networks.add_new_bus!(network, "bus_2")
+        # Branches
+        PSCOPF.Networks.add_new_branch!(network, "branch_1_2", 5.);
+        # PTDF
+        PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_1", 0.5)
+        PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_2", -0.5)
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 200.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 160.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 180.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_2", DateTime("2015-01-01T11:00:00"), "S1", 20.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict{String, SortedDict{Dates.DateTime, PSCOPF.DecisionFirmness} }(),
+                    SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE)),
+                    )
+        # initial generators state : No need because all pmin=0 => ON by default
+        generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        market = PSCOPF.EnergyMarket()
+        result = PSCOPF.run(market, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
+        # Limitable produces to the available level
+        @test 160. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1")
+
+        # Total cut conso
+        @test 40. ≈ value(result.slack_model.p_cut_conso[TS[1], "S1"])
+
+        # cut conso distributed on buses
+        @test 0.2 ≈ 40 / 200 # 40:cut_conso, 200:total load
+        @test (0.2 * 180) ≈ context.market_schedule.cut_conso_by_bus["bus_1", TS[1], "S1"]
+        @test (0.2 * 20.) ≈ context.market_schedule.cut_conso_by_bus["bus_2", TS[1], "S1"]
+    end
+
+    #TODO : illustrate ptdf effect
 
 end

--- a/test/test_wip/test_models/energy_market/test_slacks.jl
+++ b/test/test_wip/test_models/energy_market/test_slacks.jl
@@ -1,8 +1,9 @@
 using PSCOPF
 
 using Test
-using Dates
 using JuMP
+using Dates
+using DataStructures
 
 @testset verbose=true "test_energy_market_slacks" begin
 

--- a/test/test_wip/test_models/energy_market/test_slacks.jl
+++ b/test/test_wip/test_models/energy_market/test_slacks.jl
@@ -188,7 +188,7 @@ using DataStructures
         PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
 
         # TODO a status to indicate using slacks for feasibility
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         # S1 : prod_capacity < load => cannot satisfy demand
         @test 100. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
         @test 50. ≈ value(result.slack_model.p_cut_conso[TS[1], "S1"])
@@ -217,6 +217,12 @@ using DataStructures
     (imposable) prod_1_1 |    load_1
     Pmin=20, Pmax=100    |  S1: 25
     Csta=100k, Cprop=1   |
+
+    Desired solution :
+        prod_1_1 at 25MW
+    Retrieved solution with low penalization (1e3):
+        prod_1_1 at 0
+        cut_conso : 25MW
     =#
     @testset "energy_market_careful_for_cuts_consumption_penalty" begin
         penalty = 1e3
@@ -250,15 +256,15 @@ using DataStructures
                     PSCOPF.get_target_timepoints(context),
                     context)
         PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
-        
+
         # Desired Solution
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test_broken PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
         @test_broken 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
         @test_broken value(result.slack_model.p_cut_conso[TS[1], "S1"]) < 1e-09
         @test_broken value(result.objective_model.penalty) < 1e-09
 
         # retrieved solution
-        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1") < 1e-09
         @test 25. ≈ value(result.slack_model.p_cut_conso[TS[1], "S1"])
         @test (25. * 1e3) ≈ value(result.objective_model.penalty)
@@ -321,7 +327,7 @@ using DataStructures
         PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
 
         # TODO a status to indicate using slacks for feasibility because of scenario S1
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
 
         # In S1 : Load=15, wind provides 10 => still missing 5 but pmin=20
         # => reduce consumption by 5

--- a/test/test_wip/test_models/energy_market/test_slacks.jl
+++ b/test/test_wip/test_models/energy_market/test_slacks.jl
@@ -1,0 +1,340 @@
+using PSCOPF
+
+using Test
+using Dates
+using JuMP
+
+@testset verbose=true "test_energy_market_slacks" begin
+
+    #=
+    If available power for a limitable exceeds consumption,
+      the limitable says it produces the available power level
+      but a variable indicates that we needed to cap some of the
+      available power.
+    The capping variable is global (delocalised in space but has
+      a per timestep and per scenario value)
+
+    TS: [11h]
+    S: [S1]
+                      bus 1
+                        |
+    (limitable) wind_1_1|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=1     |     load_1
+      S1: 20            | S1: 15
+      S2: 25            | S2: 25
+                        |
+    =#
+    @testset "energy_market_capping_limitable_power" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 25.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 25.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict{String, SortedDict{Dates.DateTime, PSCOPF.DecisionFirmness} }(),
+                    SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE))
+                    )
+        # initial generators state : No need because all pmin=0 => ON by default
+        generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        market = PSCOPF.EnergyMarket()
+        result = PSCOPF.run(market, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # Limitable produces to the available level
+        @test 20. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1")
+        @test 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S2")
+        # Limitable was capped when prod > load (ie. S1):
+        @test 5. ≈ value(result.limitable_model.p_capping[TS[1], "S1"])
+        # Limitable was not capped when prod <= load (ie. S2):
+        @test value(result.limitable_model.p_capping[TS[1], "S2"]) < 1e-09
+        # No penalty but we do pay for capped power
+        #(otherwise we need a per unit variable for capping to localise and reduce the unpaid costs)
+        @test value(result.objective_model.penalty) < 1e-09
+        @test value(result.objective_model.start_cost) < 1e-09
+        @test (20. + 25. ) ≈ value(result.objective_model.prop_cost)
+    end
+
+    #=
+    A paramter allows not obliging limitables to produce at their available capacities.
+    In this case, cheapest limitable will be used, and extra available power will automatically
+      get capped simply by setting the injection level of each unit freely.
+    So, the capping variable should have no effect in this case.
+
+    TS: [11h]
+    S: [S1]
+                      bus 1
+                        |
+    (limitable) wind_1_1|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=1     |     load_1
+      S1: 20            | S1: 15
+      S2: 25            | S2: 25
+                        |
+    =#
+    @testset "energy_market_does_not_need_capping_if_not_forced_limitables" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 25.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 25.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict{String, SortedDict{Dates.DateTime, PSCOPF.DecisionFirmness} }(),
+                    SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE))
+                    )
+        # initial generators state : No need because all pmin=0 => ON by default
+        generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        market = PSCOPF.EnergyMarket()
+        market.configs.force_limitables_to_uncertainty = false
+        result = PSCOPF.run(market, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # Limitable can produce less than the available level
+        @test 15. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1") < 20.
+        @test 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S2")
+        # Limitable didn't need capping
+        @test value(result.limitable_model.p_capping[TS[1], "S1"]) < 1e-09
+        @test value(result.limitable_model.p_capping[TS[1], "S2"]) < 1e-09
+        # No penalty and we only pay for what we used
+        @test value(result.objective_model.penalty) < 1e-09
+        @test value(result.objective_model.start_cost) < 1e-09
+        @test (15. + 25. ) ≈ value(result.objective_model.prop_cost) < (20. + 25.)
+    end
+
+    #=
+    It is possible to cut consumption.
+    This variable should can be used in two cases :
+    1- due to EOD constraints : we don't have enough production capacity (illustrated in S1)
+    2- due to Pmin constraints : we don't have enough demand to start a unit (illustrated in S2)
+
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                         |
+    (imposable) prod_1_1 |    load_1
+    Pmin=20, Pmax=100    |  S1: 150
+    Csta=100k, Cprop=1   |  S2: 15
+                         |  S3: 25
+    =#
+    @testset "energy_market_cuts_consumption_due_to_pmin" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Imposables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                                20., 100.,
+                                                100000., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 150.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 15.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S3", 25.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),),
+                    SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE))
+                    )
+        # initial generators state :
+        generators_init_state = SortedDict("prod_1_1" => PSCOPF.OFF)
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        market = PSCOPF.EnergyMarket()
+        result = PSCOPF.run(market, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
+
+        # TODO a status to indicate using slacks for feasibility
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        # S1 : prod_capacity < load => cannot satisfy demand
+        @test 100. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
+        @test 50. ≈ value(result.slack_model.p_cut_conso[TS[1], "S1"])
+        # S2 : load < pmin => cannot start the unit for such load
+        @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S2") < 1e-09
+        @test 15. ≈ value(result.slack_model.p_cut_conso[TS[1], "S2"])
+        # S3 : works fine
+        @test 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S3")
+        @test value(result.slack_model.p_cut_conso[TS[1], "S3"]) < 1e-09
+        # penalize cutting consumption
+        @test 1e7 ≈ market.configs.cut_conso_penalty
+        @test (50. * 1e7 + 15. * 1e7 + 0. ) ≈ value(result.objective_model.penalty)
+        @test (1e5 + 0. + 1e5) ≈ value(result.objective_model.start_cost)
+        @test (100. + 0. + 25. ) ≈ value(result.objective_model.prop_cost)
+    end
+
+    #=
+    Cutting consumption is done through penalization.
+    Careful for the chosen penalty cost with respect to production costs
+    Here, the unit starting cost is higher than the penalty
+
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                         |
+    (imposable) prod_1_1 |    load_1
+    Pmin=20, Pmax=100    |  S1: 25
+    Csta=100k, Cprop=1   |
+    =#
+    @testset "energy_market_careful_for_cuts_consumption_penalty" begin
+        penalty = 1e3
+
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Imposables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                                20., 100.,
+                                                100000., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 25.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),),
+                    SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE))
+                    )
+        # initial generators state :
+        generators_init_state = SortedDict("prod_1_1" => PSCOPF.OFF)
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        market = PSCOPF.EnergyMarket()
+        market.configs.cut_conso_penalty = penalty
+        result = PSCOPF.run(market, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
+        
+        # Desired Solution
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test_broken 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
+        @test_broken value(result.slack_model.p_cut_conso[TS[1], "S1"]) < 1e-09
+        @test_broken value(result.objective_model.penalty) < 1e-09
+
+        # retrieved solution
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+        @test 25. ≈ value(result.slack_model.p_cut_conso[TS[1], "S1"])
+        @test (25. * 1e3) ≈ value(result.objective_model.penalty)
+
+    end
+
+
+    #=
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                         |
+    (limitable) wind_1_1 |    load_1
+    Pmin=0, Pmax=100     |  S1: 15
+    Csta=0, Cprop=0.     |  S2: 25
+         S1 : 10         |
+         S1 : 10         |
+                         |
+    (imposable) prod_1_1 |
+    Pmin=20, Pmax=100    |
+    Csta=100k, Cprop=100 |
+    =#
+    @testset "energy_market_capping_limitables_due_to_imposable_pmin" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Imposables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Imposables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                                20., 100.,
+                                                100000., 100.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 10.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 10.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 25.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),),
+                    SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                               "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE))
+                    )
+        # initial generators state :
+        generators_init_state = SortedDict("prod_1_1" => PSCOPF.OFF)
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        market = PSCOPF.EnergyMarket()
+        result = PSCOPF.run(market, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_market_schedule!(context, ech, result, firmness, market)
+
+        # TODO a status to indicate using slacks for feasibility because of scenario S1
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+
+        # In S1 : Load=15, wind provides 10 => still missing 5 but pmin=20
+        # => reduce consumption by 5
+        @test 10. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+        @test value(result.limitable_model.p_capping[TS[1], "S1"]) < 1e-09
+        @test 5. ≈ value(result.slack_model.p_cut_conso[TS[1], "S1"])
+
+        # In S2 : Load=25, wind provides 10 => still missing 15 but pmin=20
+        # imposable produces 20 => 5 extra prod (20+10 - 25) => reduce wind by 5.
+        @test 10. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S2")
+        @test 20. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S2")
+        @test 5. ≈ value(result.limitable_model.p_capping[TS[1], "S2"])
+        @test value(result.slack_model.p_cut_conso[TS[1], "S2"]) < 1e-09
+    end
+
+end

--- a/test/test_wip/test_models/energy_market/test_start_cost.jl
+++ b/test/test_wip/test_models/energy_market/test_start_cost.jl
@@ -58,7 +58,7 @@ using DataStructures
     prod_1_1 is ON, prod_1_2 is ON
     We only use prod_1_1 cause its prop cost is lower
     =#
-    @testset "energy_market_no_starting_cost_if_units_already_started" begin
+    @testset "energy_market_no_starting_cost_if_units_initially_started" begin
         # initial generators state
         generators_init_state = SortedDict(
             "prod_1_1" => PSCOPF.ON,
@@ -358,10 +358,7 @@ using DataStructures
         PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 65.)
     end
 
-    #=
-    For now, we simply impose previous decided values (reference is the preceding market_schedule)
-     (=> gratis starts are not used properly)
-    =#
+    # gratis starts may be not used due to a Decided commitment
     @testset "energy_market_test_gratis_start_not_used_for_decided_values" begin
         #bus2, S2, TS:11h15 : high demand
         PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 165.)
@@ -387,7 +384,7 @@ using DataStructures
                                         generators_init_state,
                                         uncertainties, nothing)
 
-        # For market, prod_1_2 is decided, it is OFF in ts1, ON in ts2 => automatically fixed in the next step
+        # For market, prod_1_2 is decided : for ts1  it is OFF, for ts2 it can be ON
         context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
                                         "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
                                             SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,

--- a/test/test_wip/test_models/energy_market/test_start_cost.jl
+++ b/test/test_wip/test_models/energy_market/test_start_cost.jl
@@ -1,9 +1,9 @@
 using PSCOPF
 
 using Test
+using JuMP
 using Dates
 using DataStructures
-using JuMP
 
 @testset verbose=true "test_energy_market_start_cost" begin
 

--- a/test/test_wip/test_models/energy_market/test_unit_priority.jl
+++ b/test/test_wip/test_models/energy_market/test_unit_priority.jl
@@ -1,8 +1,9 @@
 using PSCOPF
 
 using Test
-using Dates
 using JuMP
+using Dates
+using DataStructures
 
 @testset verbose=true "test_energy_market_unit_priority" begin
 

--- a/test/test_wip/test_models/energy_market/test_unit_priority.jl
+++ b/test/test_wip/test_models/energy_market/test_unit_priority.jl
@@ -94,7 +94,7 @@ using JuMP
     end
 
     #=
-    If force_limitables_to_uncertainty is False,
+    If force_limitables is False,
       limitables are no longer chosen first but
       units are entirely chosen economically
 
@@ -167,7 +167,7 @@ using JuMP
 
         market = PSCOPF.EnergyMarket()
         # Change default configs
-        market.configs.force_limitables_to_uncertainty = false
+        market.configs.force_limitables = false
 
         result = PSCOPF.run(market, ech, firmness,
                     PSCOPF.get_target_timepoints(context),
@@ -186,27 +186,6 @@ using JuMP
         @test ismissing( PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S1") )
     end
 
-    #=
-    TS: [11h]
-    S: [S1]
-                        bus 1                   bus 2
-                        |                      |
-    (limitable) wind_1_1|       "1_2"          |(limitable) wind_2_1
-    Pmin=0, Pmax=100    |                      |Pmin=0, Pmax=100
-    Csta=0, Cprop=150   |                      |Csta=0, Cprop=1
-      S1: 20            |----------------------|  S1: 25
-                        |         500          |
-                        |                      |
-                        |                      |
-    (imposable) prod_1_1|                      |(imposable) prod_2_1
-    Pmin=20, Pmax=100   |                      | Pmin=5, Pmax=100
-    Csta=10k, Cprop=10  |                      | Csta=10k, Cprop=15
-                        |                      |
-                        |                      |
-                load_1  |                      |load_2
-                 S1: 15 |                      | S1: 40
-
-    =#
     #=
     In S1:
       load = 55, wind=45 => missing 10

--- a/test/test_wip/test_models/energy_market/test_unit_priority.jl
+++ b/test/test_wip/test_models/energy_market/test_unit_priority.jl
@@ -8,25 +8,30 @@ using JuMP
 
 
     #=
+    By default, Energy markets picks Limitable units first. Then, the cheapest units.
+
     TS: [11h]
     S: [S1]
-                        bus 1                   bus 2
-                        |                      |
-    (limitable) wind_1_1|       "1_2"          |(limitable) wind_2_1
-    Pmin=0, Pmax=100    |                      |Pmin=0, Pmax=100
-    Csta=0, Cprop=150   |                      |Csta=0, Cprop=1
-      S1: 20            |----------------------|  S1: 25
-                        |         500          |
-                        |                      |
-                        |                      |
-    (imposable) prod_1_1|                      |(imposable) prod_2_1
-    Pmin=0, Pmax=100    |                      | Pmin=0, Pmax=100
-    Csta=0, Cprop=10    |                      | Csta=0, Cprop=15
-                        |                      |
-                        |                      |
-                load_1  |                      |load_2
-                 S1: 15 |                      | S1: 40
-
+                        bus 1
+                        |
+    (limitable) wind_1_1|load_2
+    Pmin=0, Pmax=100    | S1: 55
+    Csta=0, Cprop=150   |
+      S1: 20            |
+                        |
+    (limitable) wind_1_2|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=1     |
+      S1: 25            |
+                        |
+    (imposable) prod_1_1|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=10    |
+                        |
+    (imposable) prod_1_2|
+     Pmin=0, Pmax=100   |
+     Csta=0, Cprop=15   |
+                        |
     =#
     @testset "energy_market_picks_renewables_first" begin
         TS = [DateTime("2015-01-01T11:00:00")]
@@ -34,18 +39,12 @@ using JuMP
         network = PSCOPF.Networks.Network()
         # Buses
         PSCOPF.Networks.add_new_bus!(network, "bus_1")
-        PSCOPF.Networks.add_new_bus!(network, "bus_2")
-        # Branches
-        PSCOPF.Networks.add_new_branch!(network, "branch_1_2", 500.);
-        # PTDF
-        PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_1", 0.5)
-        PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_2", -0.5)
         # Limitables
         PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
                                                 0., 100.,
                                                 0., 150.,
                                                 Dates.Second(0), Dates.Second(0))
-        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_2", "wind_2_1", PSCOPF.Networks.LIMITABLE,
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_2", PSCOPF.Networks.LIMITABLE,
                                                 0., 100.,
                                                 0., 1.,
                                                 Dates.Second(0), Dates.Second(0))
@@ -54,23 +53,22 @@ using JuMP
                                                 0., 100.,
                                                 0., 10.,
                                                 Dates.Second(0), Dates.Second(0))
-        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_2", "prod_2_1", PSCOPF.Networks.IMPOSABLE,
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_2", PSCOPF.Networks.IMPOSABLE,
                                                 0., 100.,
                                                 0., 15.,
                                                 Dates.Second(0), Dates.Second(0))
         # Uncertainties
         uncertainties = PSCOPF.Uncertainties()
         PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
-        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_2_1", DateTime("2015-01-01T11:00:00"), "S1", 25.)
-        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
-        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_2", DateTime("2015-01-01T11:00:00"), "S1", 40.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_2", DateTime("2015-01-01T11:00:00"), "S1", 25.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
         # firmness
         firmness = PSCOPF.Firmness(
                     SortedDict{String, SortedDict{Dates.DateTime, PSCOPF.DecisionFirmness} }(),
                     SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                                "wind_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                                "wind_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
                                 "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                                "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                                "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
                     )
         # initial generators state : No need because all pmin=0 => ON by default
         generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
@@ -87,53 +85,54 @@ using JuMP
         # Solution is optimal
         @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
         @test 20. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1")
-        @test 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_2_1", TS[1], "S1")
+        @test 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_2", TS[1], "S1")
         @test 10. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1")
-        @test PSCOPF.get_prod_value(context.market_schedule, "prod_2_1", TS[1], "S1") < 1e-09
+        @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_2", TS[1], "S1") < 1e-09
         # pmin = 0 for prod_1_1 & prod_2_1
         @test ismissing( PSCOPF.get_commitment_value(context.market_schedule, "prod_1_1", TS[1], "S1") )
-        @test ismissing( PSCOPF.get_commitment_value(context.market_schedule, "prod_2_1", TS[1], "S1") )
+        @test ismissing( PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S1") )
     end
 
     #=
+    If force_limitables_to_uncertainty is False,
+      limitables are no longer chosen first but
+      units are entirely chosen economically
+
     TS: [11h]
     S: [S1]
-                        bus 1                   bus 2
-                        |                      |
-    (limitable) wind_1_1|       "1_2"          |(limitable) wind_2_1
-    Pmin=0, Pmax=100    |                      |Pmin=0, Pmax=100
-    Csta=0, Cprop=150   |                      |Csta=0, Cprop=1
-      S1: 20            |----------------------|  S1: 25
-                        |         500          |
-                        |                      |
-                        |                      |
-    (imposable) prod_1_1|                      |(imposable) prod_2_1
-    Pmin=0, Pmax=100    |                      | Pmin=0, Pmax=100
-    Csta=0, Cprop=15    |                      | Csta=0, Cprop=10
-                        |                      |
-                        |                      |
-                load_1  |                      |load_2
-                 S1: 15 |                      | S1: 40
-
+                        bus 1
+                        |
+    (limitable) wind_1_1|load_2
+    Pmin=0, Pmax=100    | S1: 55
+    Csta=0, Cprop=150   |
+      S1: 20            |
+                        |
+    (limitable) wind_1_2|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=1     |
+      S1: 25            |
+                        |
+    (imposable) prod_1_1|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=15    |
+                        |
+    (imposable) prod_1_2|
+     Pmin=0, Pmax=100   |
+     Csta=0, Cprop=10   |
+                        |
     =#
-    @testset "energy_market_picks_renewables_then_cheaper_units" begin
+    @testset "energy_market_picks_units_by_cheapest" begin
         TS = [DateTime("2015-01-01T11:00:00")]
         ech = DateTime("2015-01-01T07:00:00")
         network = PSCOPF.Networks.Network()
         # Buses
         PSCOPF.Networks.add_new_bus!(network, "bus_1")
-        PSCOPF.Networks.add_new_bus!(network, "bus_2")
-        # Branches
-        PSCOPF.Networks.add_new_branch!(network, "branch_1_2", 500.);
-        # PTDF
-        PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_1", 0.5)
-        PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_2", -0.5)
         # Limitables
         PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
                                                 0., 100.,
                                                 0., 150.,
                                                 Dates.Second(0), Dates.Second(0))
-        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_2", "wind_2_1", PSCOPF.Networks.LIMITABLE,
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_2", PSCOPF.Networks.LIMITABLE,
                                                 0., 100.,
                                                 0., 1.,
                                                 Dates.Second(0), Dates.Second(0))
@@ -142,23 +141,22 @@ using JuMP
                                                 0., 100.,
                                                 0., 15.,
                                                 Dates.Second(0), Dates.Second(0))
-        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_2", "prod_2_1", PSCOPF.Networks.IMPOSABLE,
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_2", PSCOPF.Networks.IMPOSABLE,
                                                 0., 100.,
                                                 0., 10.,
                                                 Dates.Second(0), Dates.Second(0))
         # Uncertainties
         uncertainties = PSCOPF.Uncertainties()
         PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
-        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_2_1", DateTime("2015-01-01T11:00:00"), "S1", 25.)
-        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
-        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_2", DateTime("2015-01-01T11:00:00"), "S1", 40.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_2", DateTime("2015-01-01T11:00:00"), "S1", 25.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
         # firmness
         firmness = PSCOPF.Firmness(
                     SortedDict{String, SortedDict{Dates.DateTime, PSCOPF.DecisionFirmness} }(),
                     SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                                "wind_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                                "wind_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
                                 "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                                "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                                "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
                     )
         # initial generators state : No need because all pmin=0 => ON by default
         generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
@@ -166,7 +164,11 @@ using JuMP
         context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
                                         generators_init_state,
                                         uncertainties, nothing)
+
         market = PSCOPF.EnergyMarket()
+        # Change default configs
+        market.configs.force_limitables_to_uncertainty = false
+
         result = PSCOPF.run(market, ech, firmness,
                     PSCOPF.get_target_timepoints(context),
                     context)
@@ -174,14 +176,14 @@ using JuMP
 
         # Solution is optimal
         @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
-        @test 20. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1")
-        @test 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_2_1", TS[1], "S1")
+        @test 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_2", TS[1], "S1")
+        @test 30. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1") < 1e-09
         @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1") < 1e-09
-        @test 10. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_2_1", TS[1], "S1")
 
         # pmin = 0 for prod_1_1 & prod_2_1
         @test ismissing( PSCOPF.get_commitment_value(context.market_schedule, "prod_1_1", TS[1], "S1") )
-        @test ismissing( PSCOPF.get_commitment_value(context.market_schedule, "prod_2_1", TS[1], "S1") )
+        @test ismissing( PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S1") )
     end
 
     #=
@@ -205,56 +207,77 @@ using JuMP
                  S1: 15 |                      | S1: 40
 
     =#
-    @testset "energy_market_picks_cheapest_respecting_pmin" begin
+    #=
+    In S1:
+      load = 55, wind=45 => missing 10
+      prod_1_1 has a pmin=20 => we produce 20 costing 200 (20MW*10)
+                                + we cap 10MW of wind (which here we paid for cause Cprop(wind)=1)
+      prod_1_2 has a pmin=5 => we produce 10 costing 150 (10MW*15)
+    => use prod_1_2
+    In S2:
+      load = 60, wind=45 => missing 15
+      prod_1_1 has a pmin=20 => we produce 20 costing 200 (20MW*10)
+                                + we cap 5MW of wind (which here we paid for cause Cprop(wind)=1)
+      prod_1_2 has a pmin=5 => we produce 15 costing 225 (15MW*15)
+    => use prod_1_1
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                        |
+    (limitable) wind_1_1|load_2
+    Pmin=0, Pmax=100    | S1: 55
+    Csta=0, Cprop=1     | S2: 60
+      S1: 45            |
+      S2: 45            |
+                        |
+    (imposable) prod_1_1|
+    Pmin=20, Pmax=100   |
+    Csta=0, Cprop=10    |
+                        |
+    (imposable) prod_1_2|
+     Pmin=5, Pmax=100   |
+     Csta=0, Cprop=15   |
+                        |
+    =#
+    @testset "energy_market_picks_cheapest_respecting_pmin_and_capping" begin
         TS = [DateTime("2015-01-01T11:00:00")]
         ech = DateTime("2015-01-01T07:00:00")
         network = PSCOPF.Networks.Network()
         # Buses
         PSCOPF.Networks.add_new_bus!(network, "bus_1")
-        PSCOPF.Networks.add_new_bus!(network, "bus_2")
-        # Branches
-        PSCOPF.Networks.add_new_branch!(network, "branch_1_2", 500.);
-        # PTDF
-        PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_1", 0.5)
-        PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_2", -0.5)
         # Limitables
         PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
                                                 0., 100.,
-                                                0., 150.,
-                                                Dates.Second(0), Dates.Second(0))
-        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_2", "wind_2_1", PSCOPF.Networks.LIMITABLE,
-                                                0., 100.,
                                                 0., 1.,
                                                 Dates.Second(0), Dates.Second(0))
-        # Imposables
+        # Imposables : have a Pmin but no start cost
         PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
                                                 20., 100.,
-                                                10000., 10.,
+                                                0., 10.,
                                                 Dates.Second(0), Dates.Second(0))
-        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_2", "prod_2_1", PSCOPF.Networks.IMPOSABLE,
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_2", PSCOPF.Networks.IMPOSABLE,
                                                 5., 100.,
-                                                10000., 15.,
+                                                0., 15.,
                                                 Dates.Second(0), Dates.Second(0))
         # Uncertainties
         uncertainties = PSCOPF.Uncertainties()
-        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
-        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_2_1", DateTime("2015-01-01T11:00:00"), "S1", 25.)
-        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
-        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_2", DateTime("2015-01-01T11:00:00"), "S1", 40.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 45.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 45.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
         # firmness
         firmness = PSCOPF.Firmness(
                     SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                                "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                                "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
                             ),
                     SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                                "wind_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
                                 "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
-                                "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                                "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
                     )
         # initial generators state
         generators_init_state = SortedDict(
             "prod_1_1" => PSCOPF.ON,
-            "prod_2_1" => PSCOPF.ON
+            "prod_1_2" => PSCOPF.ON
         )
 
         context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
@@ -269,17 +292,27 @@ using JuMP
         # Solution is optimal
         @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
 
-        @test 20. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1")
-        @test 25. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_2_1", TS[1], "S1")
-        @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1") < 1e-09 #cheapest but pmin=20
-        @test 10. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_2_1", TS[1], "S1")
-
+        #S1
+        @test 45. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S1")
         @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_1", TS[1], "S1")
-        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_2_1", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S1") < 1e-09 #cheapest but pmin=20
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S1")
+        @test 10. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_2", TS[1], "S1")
+        @test value(result.limitable_model.p_capping[TS[1], "S1"]) < 1e-09
+
+        #S2
+        @test 45. ≈ PSCOPF.get_prod_value(context.market_schedule, "wind_1_1", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_1", TS[1], "S2")
+        @test 20. ≈ PSCOPF.get_prod_value(context.market_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.market_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.get_prod_value(context.market_schedule, "prod_1_2", TS[1], "S2") < 1e-09
+        @test 5. ≈ value(result.limitable_model.p_capping[TS[1], "S2"])
 
         @test value(result.objective_model.start_cost) < 1e-09
-        @test (20. * 150 + 25. * 1 + 0. + 10. * 15) ≈ value(result.objective_model.prop_cost)
-
+        @test value(result.objective_model.prop_cost) ≈ (
+              (45. * 1 + 0. * 10. + 10. * 15) #S1
+            + (45. * 1 + 20. * 10. + 0. * 15) #S2
+        )
     end
 
 end

--- a/test/test_wip/test_models/tso_out_fo/test_constraints.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_constraints.jl
@@ -1,0 +1,190 @@
+using PSCOPF
+
+using Test
+using JuMP
+using Dates
+using DataStructures
+using Printf
+
+@testset verbose=true "test_tso_constraints" begin
+
+    #=
+    TS: [11h, 11h15]
+    S: [S1,S2]
+                        bus 1                   bus 2
+                        |                      |
+    (limitable) wind_1_1|       "1_2"          |
+    Pmin=0, Pmax=100    |                      |
+    Csta=0, Cprop=1     |                      |
+      S1: 20    S1: 15  |----------------------|
+      S2: 30    S2: 30  |         35           |
+                        |                      |
+                        |                      |
+    (imposable) prod_1_1|                      |(imposable) prod_2_1
+    Pmin=10, Pmax=100   |                      | Pmin=10, Pmax=100
+    Csta=45k, Cprop=10  |                      | Csta=80k, Cprop=15
+    ON                  |                      | ON
+                        |                      |
+           load(bus_1)  |                      |load(bus_2)
+      S1: 10     S1: 15 |                      | S1: 40  S1: 50
+      S2: 10     S2: 15 |                      | S2: 45  S2: 50
+
+    =#
+
+    TS = [DateTime("2015-01-01T11:00:00"), DateTime("2015-01-01T11:15:00")]
+    ech = DateTime("2015-01-01T07:00:00")
+    network = PSCOPF.Networks.Network()
+    # Buses
+    PSCOPF.Networks.add_new_bus!(network, "bus_1")
+    PSCOPF.Networks.add_new_bus!(network, "bus_2")
+    # Branches
+    PSCOPF.Networks.add_new_branch!(network, "branch_1_2", 35.);
+    # PTDF
+    PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_1", 0.5)
+    PSCOPF.Networks.add_ptdf_elt!(network, "branch_1_2", "bus_2", -0.5)
+    # Limitables
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                            0., 100.,
+                                            0., 1.,
+                                            Dates.Second(0), Dates.Second(0))
+    # Imposables
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                            10., 100.,
+                                            45000., 10.,
+                                            Dates.Second(0), Dates.Second(0))
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_2", "prod_2_1", PSCOPF.Networks.IMPOSABLE,
+                                            10., 100.,
+                                            80000., 15.,
+                                            Dates.Second(0), Dates.Second(0))
+    # initial generators state
+    generators_init_state = SortedDict(
+                    "prod_1_1" => PSCOPF.ON,
+                    "prod_2_1" => PSCOPF.ON
+                )
+    # Uncertainties
+    uncertainties = PSCOPF.Uncertainties()
+    PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 30.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:15:00"), "S1", 15.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:15:00"), "S2", 30.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 10.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 10.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S1", 15.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 15.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_2", DateTime("2015-01-01T11:00:00"), "S1", 40.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_2", DateTime("2015-01-01T11:00:00"), "S2", 45.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_2", DateTime("2015-01-01T11:15:00"), "S1", 50.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_2", DateTime("2015-01-01T11:15:00"), "S2", 50.)
+    # firmness
+    firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE,),
+                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE,), ),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE,),
+                            "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE,),
+                            "prod_2_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE,), )
+                )
+
+
+    context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                    generators_init_state,
+                                    uncertainties, nothing)
+
+    context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+        "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+            SortedDict(),
+            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.Float64}(missing,
+                                                                                    SortedDict("S1"=>20., "S2"=>30.)),
+                        Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.Float64}(missing,
+                                                                                    SortedDict("S1"=>15., "S2"=>30.)),
+                        ),
+            ),
+        "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                    SortedDict("S1"=>PSCOPF.ON, "S2"=>PSCOPF.ON)),
+                        Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                    SortedDict("S1"=>PSCOPF.ON, "S2"=>PSCOPF.ON)),
+                        ),
+            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.Float64}(missing,
+                                                                                    SortedDict("S1"=>30., "S2"=>35.)),
+                        Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.Float64}(missing,
+                                                                                    SortedDict("S1"=>40., "S2"=>35.)),
+                        ),
+            ),
+        "prod_2_1" => PSCOPF.GeneratorSchedule("prod_2_1",
+            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                    SortedDict("S1"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                        Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                    SortedDict("S1"=>PSCOPF.ON, "S2"=>PSCOPF.ON)),
+                        ),
+            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.Float64}(missing,
+                                                                                    SortedDict("S1"=>0., "S2"=>0.)),
+                        Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.Float64}(missing,
+                                                                                    SortedDict("S1"=>0., "S2"=>0.)),
+                        ),
+            ),
+        )
+    )
+    
+    tso = PSCOPF.TSOOutFO()
+    result = PSCOPF.run(tso, ech, firmness,
+                PSCOPF.get_target_timepoints(context),
+                context)
+    PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+    @testset "tso_successful_launch" begin
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+    end
+
+    @testset "tso_updated_schedule_respects_the_input_firmness" begin
+        @test context.tso_schedule.decision_time == ech
+        @test PSCOPF.verify_firmness(firmness, context.tso_schedule,
+                        excluded_ids=PSCOPF.get_limitables_ids(context))
+    end
+
+    @testset "tso_respects_EOD" begin
+        @test context.tso_schedule.decision_time == ech
+        @test PSCOPF.verify_firmness(firmness, context.tso_schedule,
+                        excluded_ids=PSCOPF.get_limitables_ids(context))
+        for ts in TS
+            for s in ["S1", "S2"]
+                @test ( abs( PSCOPF.compute_eod(PSCOPF.get_uncertainties(context),
+                                        PSCOPF.get_tso_schedule(context),
+                                        PSCOPF.get_network(context),
+                                        ech, ts, s) )
+                        < 1e-09 )
+            end
+        end
+    end
+
+    @testset "tso_respects_RSO_constraints" begin
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+
+        #prod_2_1 is used for RSO constraints
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_2_1", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_2_1", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_2_1", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_2_1", TS[2], "S2")
+        #prod_1_1 might be used to deviate the least from market schedule
+
+        # Note : compute_flow does not consider cut_conso (valid here cause cut_conso=0, proven by pscopf_OPTIMAL)
+        for ts in TS
+            for s in ["S1", "S2"]
+                flow = PSCOPF.compute_flow("branch_1_2",
+                                        PSCOPF.get_uncertainties(context),
+                                        PSCOPF.get_tso_schedule(context),
+                                        PSCOPF.get_network(context),
+                                        ech, ts, s)
+                @printf("ts:%s, s:%s : %f\n", ts, s, flow)
+                @test ( -35. <= flow <= 35. ) #flow exceeds branch limit
+            end
+        end
+    end
+
+end

--- a/test/test_wip/test_models/tso_out_fo/test_dmo.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_dmo.jl
@@ -1,0 +1,257 @@
+using PSCOPF
+
+using Test
+using JuMP
+using Dates
+using DataStructures
+
+@testset verbose=true "test_tso_out_fo_dmo" begin
+
+    #=
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                        |
+    (imposable) prod_1_1|load
+    Pmin=10, Pmax=100   |
+    Csta=0, Cprop=10    |
+    DMO => 8h           |
+                        |
+    =#
+
+    TS = [DateTime("2015-01-01T11:00:00")]
+    network = PSCOPF.Networks.Network()
+    # Buses
+    PSCOPF.Networks.add_new_bus!(network, "bus_1")
+    # Imposables
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                            10., 100.,
+                                            0., 10.,
+                                            Dates.Second(3*60*60), Dates.Second(0))
+    # Uncertainties
+    uncertainties = PSCOPF.Uncertainties()
+    # initial generators state : need to pay starting cost at TS[1]
+    generators_init_state = SortedDict(
+        "prod_1_1" => PSCOPF.OFF,
+    )
+    mode = PSCOPF.ManagementMode("mode_5mins", Dates.Minute(5))
+
+    # before DMO + still have an ech to decide on => commitment firmness is FREE
+    @testset "tso_can_start_unit_before_DMO" begin
+        ech = DateTime("2015-01-01T07:00:00")
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
+
+        # firmness
+        expected_firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), ),
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S1"=>PSCOPF.OFF))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.)))
+                ),
+            )
+        )
+
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T07:00:00"), SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S1"=>PSCOPF.OFF))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.)))
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+
+        firmness = PSCOPF.compute_firmness(tso, ech, #7h
+                                            DateTime("2015-01-01T08:00:00"), # corresponds to ECH-DMO
+                                            TS, context)
+        @test firmness == expected_firmness
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # we started prod_1_1
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test 20. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+    end
+
+    @testset "tso_cannot_start_unit_after_DMO" begin
+        ech = DateTime("2015-01-01T10:00:00")
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
+
+        # firmness
+        expected_firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                        SortedDict("S1"=>PSCOPF.OFF))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.)))
+                ),
+            )
+        )
+
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T07:00:00"), SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                        SortedDict("S1"=>PSCOPF.OFF))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.)))
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+
+        firmness = PSCOPF.compute_firmness(tso, ech, #10h
+                                            DateTime("2015-01-01T10:30:00"), # corresponds to ECH-DMO
+                                            TS, context)
+        @test firmness == expected_firmness
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution uses slack
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        # we could not start prod_1_1
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+        @test 20. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"])
+    end
+
+    @testset "tso_cannot_start_unit_after_DMO_even_if_market_does" begin
+        ech = DateTime("2015-01-01T10:00:00")
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
+
+        # firmness
+        expected_firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                        SortedDict("S1"=>PSCOPF.OFF))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.)))
+                ),
+            )
+        )
+
+        # market uses prod_1_1 but tso didn't (This should not happen as TSO dictates commitment)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T07:00:00"), SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                        SortedDict("S1"=>PSCOPF.ON))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>20.)))
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+
+        firmness = PSCOPF.compute_firmness(tso, ech, #10h
+                                            DateTime("2015-01-01T10:30:00"), # corresponds to ECH-DMO
+                                            TS, context)
+        @test firmness == expected_firmness
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution uses slack
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        # we could not start prod_1_1
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+        @test 20. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"])
+    end
+
+    @testset "tso_can_shutdown_unit_after_DMO" begin
+        ech = DateTime("2015-01-01T10:00:00")
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 0.)
+
+        # firmness
+        expected_firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                        SortedDict("S1"=>PSCOPF.ON))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>20.)))
+                ),
+            )
+        )
+
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T07:00:00"), SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                        SortedDict("S1"=>PSCOPF.ON))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>20.)))
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+
+        firmness = PSCOPF.compute_firmness(tso, ech, #10h
+                                            DateTime("2015-01-01T10:30:00"), # corresponds to ECH-DMO
+                                            TS, context)
+        @test firmness == expected_firmness
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # 0 demand => we shutdown the unit
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+    end
+
+end

--- a/test/test_wip/test_models/tso_out_fo/test_dmo.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_dmo.jl
@@ -138,7 +138,7 @@ using DataStructures
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
         # Solution uses slack
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         # we could not start prod_1_1
         @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
         @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
@@ -193,7 +193,7 @@ using DataStructures
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
         # Solution uses slack
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         # we could not start prod_1_1
         @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
         @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09

--- a/test/test_wip/test_models/tso_out_fo/test_dp_imposable.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_dp_imposable.jl
@@ -224,7 +224,7 @@ using DataStructures
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
         # Solution is optimal but has slack due to infeasibility
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         # prod_1_1 is OFF cause it already was OFF:
         @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
         @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
@@ -302,7 +302,7 @@ using DataStructures
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
         # Solution is optimal but has slack due to infeasibility
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         # prod_1_1 is OFF cause it already was OFF:
         @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
         @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09

--- a/test/test_wip/test_models/tso_out_fo/test_dp_imposable.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_dp_imposable.jl
@@ -1,0 +1,316 @@
+using PSCOPF
+
+using Test
+using JuMP
+using Dates
+using DataStructures
+
+@testset verbose=true "test_tso_out_fo_dp_imposable" begin
+
+    #=
+    TS: [11h]
+    S: [S1]
+                      bus 1
+                        |
+    (imposable) prod_1_1|load
+     Pmin=10, Pmax=100  | S1: 55
+     Csta=0, Cprop=10   |
+     DP => 10h30        |
+                        |
+    (imposable) prod_1_2|
+     Pmin=10, Pmax=100  |
+     Csta=0, Cprop=15   |
+     DP => 10h45        |
+                        |
+
+    =#
+
+    TS = [DateTime("2015-01-01T11:00:00")]
+    network = PSCOPF.Networks.Network()
+    # Buses
+    PSCOPF.Networks.add_new_bus!(network, "bus_1")
+    # Imposables
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                            10., 100.,
+                                            0., 10.,
+                                            Dates.Second(3*60*60), Dates.Second(30*60))
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_2", PSCOPF.Networks.IMPOSABLE,
+                                            10., 100.,
+                                            0., 15.,
+                                            Dates.Second(3*60*60), Dates.Second(15*60))
+    # Uncertainties
+    uncertainties = PSCOPF.Uncertainties()
+    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:00:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+    PSCOPF.add_uncertainty!(uncertainties, DateTime("2015-01-01T10:50:00"), "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+    # initial generators state : need to pay starting cost at TS[1]
+    generators_init_state = SortedDict(
+        "prod_1_1" => PSCOPF.OFF,
+        "prod_1_2" => PSCOPF.OFF
+    )
+    #ManagementMode
+    mode = PSCOPF.ManagementMode("test_mode", Dates.Minute(5))
+
+    #=
+            ECH   TS
+    |        |    |
+            10h   11h
+             <---->
+               FO
+    =#
+    @testset "tso_cannot_be_launched_after_or_at_FO" begin
+        ech = DateTime("2015-01-01T10:00:00")
+        mode1 = PSCOPF.PSCOPF_MODE_1 # FO == 10h
+
+        # firmness : wrong firmness % ech/DMO/DP but doesn't matter
+        firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), ),
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        tso = PSCOPF.TSOOutFO()
+        @test_throws ErrorException PSCOPF.run(tso, ech, firmness,
+                                                PSCOPF.get_target_timepoints(context),
+                                                context)
+    end
+
+
+    #=
+    ECH1*         ECH2            ECH3                                 <---FO--->TS
+    |             |               |
+    10h           10h30           10h40          10h45                          11h
+                  <------------------------------------------DP(prod1)----------->
+                                                   <---------DP(prod2)----------->
+    =#
+    @testset "tso_can_change_the_production_level_before_dp_if_ON" begin
+        ech = DateTime("2015-01-01T10:00:00")
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
+                                        "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                                                    SortedDict("S1"=>PSCOPF.OFF))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>0.)))
+                                            ),
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>50.)))
+                                            )
+                                        )
+                                    )
+
+        # Market schedule does not respect EOD for ech=10h, ts=11h, S1
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T10:00:00"), SortedDict(
+                                        "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                                                    SortedDict("S1"=>PSCOPF.OFF))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>0.)))
+                                            ),
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>60.)))
+                                            )
+                                        )
+                                )
+
+        tso = PSCOPF.TSOOutFO()
+
+        @test firmness == PSCOPF.compute_firmness(tso,
+                                                ech, DateTime("2015-01-01T10:30:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # prod_1_1 is OFF cause it already was OFF:
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+        # prod_1_2 was ON, it can change it's production : 50 => 55.
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test 55. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+    end
+
+
+    #=
+    ECH1          ECH2            ECH3           ECH4        ECH5*    <---FO--->TS
+    |             |               |
+    10h           10h30           10h40          10h45                          11h
+                  <------------------------------------------DP(prod1)----------->
+                                                   <---------DP(prod2)----------->
+    =#
+    @testset "tso_cannot_change_the_production_level_after_dp" begin
+        ech = DateTime("2015-01-01T10:50:00")
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T10:45:00"), SortedDict(
+                                        "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                                                    SortedDict("S1"=>PSCOPF.OFF))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(0.,
+                                                                                                                    SortedDict("S1"=>0.)))
+                                            ),
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(50.,
+                                                                                                                    SortedDict("S1"=>50.)))
+                                            )
+                                        )
+                                    )
+
+        # Market schedule can not be adopted, cause it will imply changing an already decided production (prod_1_2) after DP
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T10:50:00"), SortedDict(
+                                        "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                                                    SortedDict("S1"=>PSCOPF.OFF))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(0.,
+                                                                                                                    SortedDict("S1"=>0.)))
+                                            ),
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(55.,
+                                                                                                                    SortedDict("S1"=>55.)))
+                                            )
+                                        )
+                                )
+
+        tso = PSCOPF.TSOOutFO()
+
+        @test firmness == PSCOPF.compute_firmness(tso,
+                                                ech, DateTime("2015-01-01T10:55:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal but has slack due to infeasibility
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        # prod_1_1 is OFF cause it already was OFF:
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+        # prod_1_2 cannot be changed after DP
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test 50. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        # slack for feasibility
+        @test 5. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"])
+    end
+
+    #=
+    ECH1*         ECH2            ECH3           ECH4                  <---FO--->TS
+    |             |               |
+    10h           10h30           10h40          10h45                          11h
+                  <------------------------------------------DP(prod1)----------->
+                                                   <---------DP(prod2)----------->
+    =#
+    @testset "tso_cannot_change_the_production_level_before_dp_if_unit_is_off_and_past_DMO" begin
+        ech = DateTime("2015-01-01T10:00:00")
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), ),
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
+                                        "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                                                    SortedDict("S1"=>PSCOPF.OFF))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>0.)))
+                                            ),
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                                                    SortedDict("S1"=>PSCOPF.OFF))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>0.)))
+                                            )
+                                        )
+                                    )
+
+        # Market schedule can not be adopted, cause it will imply changing an already decided production (prod_1_2) after DP
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T10:00:00"), SortedDict(
+                                        "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                                                    SortedDict("S1"=>PSCOPF.OFF))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>55.)))
+                                            ),
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON))),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>0.)))
+                                            )
+                                        )
+                                )
+
+        tso = PSCOPF.TSOOutFO()
+
+        @test firmness == PSCOPF.compute_firmness(tso,
+                                                ech, DateTime("2015-01-01T10:30:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal but has slack due to infeasibility
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        # prod_1_1 is OFF cause it already was OFF:
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+        # prod_1_2 cannot be changed after DP
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S1") < 1e-09
+        # slack for feasibility
+        @test 55. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"])
+    end
+
+end

--- a/test/test_wip/test_models/tso_out_fo/test_dp_limitable.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_dp_limitable.jl
@@ -96,7 +96,7 @@ using DataStructures
         @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
         # Limit was changed since we are before DP
         @test value(result.limitable_model.p_limit["wind_1_1",TS[1]]) > 55. == OLD_LIMIT
-        @test 60. <= value(result.limitable_model.p_limit["wind_1_1",TS[1]]) <= 100.
+        @test 60. - 1e-09 <= value(result.limitable_model.p_limit["wind_1_1",TS[1]]) <= 100. + 1e-09
         #But this is not an active limit
         @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
         @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09

--- a/test/test_wip/test_models/tso_out_fo/test_dp_limitable.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_dp_limitable.jl
@@ -1,0 +1,245 @@
+using PSCOPF
+
+using Test
+using JuMP
+using Dates
+using DataStructures
+
+@testset verbose=true "test_tso_out_fo_dp" begin
+
+    #=
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                        |
+    (limitable) wind_1_1|load
+    Pmin=0, Pmax=100    | S1: 55
+    Csta=0, Cprop=1     | S2: 60
+    DP => 10h40         |
+      S1: 55            |
+      S2: 60            |
+    =#
+
+    TS = [DateTime("2015-01-01T11:00:00")]
+    network = PSCOPF.Networks.Network()
+    # Buses
+    PSCOPF.Networks.add_new_bus!(network, "bus_1")
+    # Limitables
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                            0., 100.,
+                                            0., 1.,
+                                            Dates.Second(20*60), Dates.Second(20*60))
+    # Uncertainties
+    uncertainties = PSCOPF.Uncertainties()
+    # initial generators state : need to pay starting cost at TS[1]
+    generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+    #ManagementMode
+    mode = PSCOPF.ManagementMode("test_mode", Dates.Minute(5))
+
+    #=
+    ECH1*                    ECH2              ECH3         <---FO--->TS
+    |                        |
+    10h                      10h40             10h45                 11h
+                             <--------------------DP(wind1)----------->
+    =#
+    @testset "tso_out_fo_can_change_the_limit_before_dp" begin
+        ech = DateTime("2015-01-01T10:00:00")
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict(),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        #This limit should be ignored because firmness is FREE
+        OLD_LIMIT = 55.
+        PSCOPF.set_limitation_value!(context.tso_actions, "wind_1_1", TS[1], OLD_LIMIT)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
+                                            "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                                                SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                                                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                        SortedDict("S1"=>55.,"S2"=>55.)))
+                                                ),
+                                            )
+                                    )
+
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T10:00:00"), SortedDict(
+                                        "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                                            SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>57.,"S2"=>62.)))
+                                            ),
+                                        )
+                                )
+
+        tso = PSCOPF.TSOOutFO()
+
+        @test firmness == PSCOPF.compute_firmness(tso,
+                                                ech, DateTime("2015-01-01T10:40:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # Limit was changed since we are before DP
+        @test value(result.limitable_model.p_limit["wind_1_1",TS[1]]) > 55. == OLD_LIMIT
+        @test 60. <= value(result.limitable_model.p_limit["wind_1_1",TS[1]]) <= 100.
+        #But this is not an active limit
+        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
+        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
+        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
+    end
+
+    #=
+    ECH1                    ECH2              ECH3*         <---FO--->TS
+    |                        |
+    10h                      10h40             10h45                 11h
+                             <--------------------DP(wind1)----------->
+    =#
+    @testset "tso_out_fo_cannot_increase_the_limit_after_dp" begin
+        ech = DateTime("2015-01-01T10:45:00")
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict(),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        OLD_LIMIT = 55.
+        PSCOPF.set_limitation_value!(context.tso_actions, "wind_1_1", TS[1], OLD_LIMIT)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T10:40:00"), SortedDict(
+                                            "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                                                SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                                                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                        SortedDict("S1"=>55.,"S2"=>55.)))
+                                                ),
+                                            )
+                                    )
+
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T10:45:00"), SortedDict(
+                                        "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                                            SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>57.,"S2"=>62.)))
+                                            ),
+                                        )
+                                )
+
+        tso = PSCOPF.TSOOutFO()
+
+        @test firmness == PSCOPF.compute_firmness(tso,
+                                                ech, DateTime("2015-01-01T10:50:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution has slacks
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        # Limit cannot be changed after DP : Ideally we would have 60. to use all available limitable power
+        @test 55. == OLD_LIMIT ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]])
+
+        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
+        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
+        @test 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"])
+        @test 55. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"])
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+        @test 5 ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"])
+    end
+
+    #=
+    ECH1                    ECH2              ECH3*         <---FO--->TS
+    |                        |
+    10h                      10h40             10h45                 11h
+                             <--------------------DP(wind1)----------->
+    =#
+    @testset "tso_out_fo_cannot_decrease_the_limit_after_dp" begin
+        ech = DateTime("2015-01-01T10:45:00")
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict(),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        OLD_LIMIT = 70.
+        PSCOPF.set_limitation_value!(context.tso_actions, "wind_1_1", TS[1], OLD_LIMIT)
+
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T10:40:00"), SortedDict(
+                                            "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                                                SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                                                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                        SortedDict("S1"=>70.,"S2"=>70.)))
+                                                ),
+                                            )
+                                    )
+
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T10:45:00"), SortedDict(
+                                        "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                                            SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                                    SortedDict("S1"=>57.,"S2"=>62.)))
+                                            ),
+                                        )
+                                )
+
+        tso = PSCOPF.TSOOutFO()
+
+        @test firmness == PSCOPF.compute_firmness(tso,
+                                                ech, DateTime("2015-01-01T10:50:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution has slacks
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        # Limit cannot be changed after DP : Ideally we would have 60. to use all available limitable power
+        @test 70. == OLD_LIMIT ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]])
+
+        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
+        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
+        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
+    end
+
+end

--- a/test/test_wip/test_models/tso_out_fo/test_dp_limitable.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_dp_limitable.jl
@@ -98,10 +98,8 @@ using DataStructures
         @test value(result.limitable_model.p_limit["wind_1_1",TS[1]]) > 55. == OLD_LIMIT
         @test 60. - 1e-09 <= value(result.limitable_model.p_limit["wind_1_1",TS[1]]) <= 100. + 1e-09
         #But this is not an active limit
-        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
-        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
-        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
-        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test ! PSCOPF.is_limited("wind_1_1",TS[1], "S1", result.limitable_model, uncertainties[ech])
+        @test ! PSCOPF.is_limited("wind_1_1",TS[1], "S2", result.limitable_model, uncertainties[ech])
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
     end
@@ -166,10 +164,8 @@ using DataStructures
         # Limit cannot be changed after DP : Ideally we would have 60. to use all available limitable power
         @test 55. == OLD_LIMIT ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]])
 
-        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
-        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
-        @test 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"])
-        @test 55. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"])
+        @test ! PSCOPF.is_limited("wind_1_1",TS[1], "S1", result.limitable_model, uncertainties[ech])
+        @test PSCOPF.is_limited("wind_1_1",TS[1], "S2", result.limitable_model, uncertainties[ech])
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
         @test 5 ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"])
     end
@@ -234,11 +230,9 @@ using DataStructures
         # Limit cannot be changed after DP : Ideally we would have 60. to use all available limitable power
         @test 70. == OLD_LIMIT ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]])
 
-        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
-        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
+        @test ! PSCOPF.is_limited("wind_1_1",TS[1], "S1", result.limitable_model, uncertainties[ech])
         @test 55. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1], "S1"])
-        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
-        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test ! PSCOPF.is_limited("wind_1_1",TS[1], "S2", result.limitable_model, uncertainties[ech])
         @test 60. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1], "S2"])
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09

--- a/test/test_wip/test_models/tso_out_fo/test_dp_limitable.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_dp_limitable.jl
@@ -162,7 +162,7 @@ using DataStructures
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
         # Solution has slacks
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         # Limit cannot be changed after DP : Ideally we would have 60. to use all available limitable power
         @test 55. == OLD_LIMIT ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]])
 
@@ -230,14 +230,16 @@ using DataStructures
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
         # Solution has slacks
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
         # Limit cannot be changed after DP : Ideally we would have 60. to use all available limitable power
         @test 70. == OLD_LIMIT ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]])
 
         @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
         @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09
+        @test 55. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1], "S1"])
         @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
         @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test 60. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1], "S2"])
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
     end

--- a/test/test_wip/test_models/tso_out_fo/test_limitation.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_limitation.jl
@@ -68,13 +68,11 @@ using DataStructures
         @test 30. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S1"])
         @test 35. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S2"])
 
-        @test_broken 35. ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]]) # now 60, should be 35 ? 30 ?
+        @test 35. ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]]) # should be 35 ? 30 ? 60 ? 100 ?
 
         # active limits ?
-        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) # now 0, should be 1 ?
-        @test_broken 35. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) # now 0, should be 35 ?
-        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) # now 0, should be 1 ?
-        @test_broken 35. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"]) # now 0, should be 35 ?
+        @test PSCOPF.is_limited("wind_1_1",TS[1], "S1", result.limitable_model, uncertainties[ech])
+        @test PSCOPF.is_limited("wind_1_1",TS[1], "S2", result.limitable_model, uncertainties[ech])
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
     end
@@ -143,10 +141,8 @@ using DataStructures
         @test 60. ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]])
 
         # active limits ?
-        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) # now 0. should be 1 ?
-        @test_broken 35. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09 # now 0. should be 30 ? 35 ?
-        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
-        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test PSCOPF.is_limited("wind_1_1",TS[1], "S1", result.limitable_model, uncertainties[ech])
+        @test ! PSCOPF.is_limited("wind_1_1",TS[1], "S2", result.limitable_model, uncertainties[ech])
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
     end
@@ -213,13 +209,11 @@ using DataStructures
         @test 30. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S1"])
         @test 60. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S2"])
 
-        @test 70. ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]]) # should be 60 ? 70 ? 100 ?
+        @test 60. ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]]) # should be 60 ? 70 ? 100 ?
 
         # active limits ?
-        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) # now 0. should be 1 ?
-        @test_broken 30. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) # now 0. should be 30 ? 60 ? 70 ? 100 ?
-        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) # now 0. should be 1 ?
-        @test_broken 60. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"])  # now 0. should be 60 ? 70 ? 100 ?
+        @test PSCOPF.is_limited("wind_1_1",TS[1], "S1", result.limitable_model, uncertainties[ech])
+        @test ! PSCOPF.is_limited("wind_1_1",TS[1], "S2", result.limitable_model, uncertainties[ech])
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
     end

--- a/test/test_wip/test_models/tso_out_fo/test_limitation.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_limitation.jl
@@ -1,0 +1,228 @@
+using PSCOPF
+
+using Test
+using JuMP
+using Dates
+using DataStructures
+
+@testset verbose=true "test_tso_out_fo_dp" begin
+
+    #=
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                        |
+    (limitable) wind_1_1|load
+    Pmin=0, Pmax=100    | S1: 30
+    Csta=0, Cprop=1     | S2: 35
+      S1: 55            |
+      S2: 60            |
+    =#
+    @testset "tso_limits_limitables" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T10:00:00")
+        network = PSCOPF.Networks.Network()
+        # Buses
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        # initial generators state : need to pay starting cost at TS[1]
+        generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+        #ManagementMode
+        mode = PSCOPF.ManagementMode("test_mode", Dates.Minute(5))
+
+
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 30.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 35.)
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict(),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        tso = PSCOPF.TSOOutFO()
+
+        @test firmness == PSCOPF.compute_firmness(tso,
+                                                ech, DateTime("2015-01-01T10:40:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # Limit
+        @test 30. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S1"])
+        @test 35. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S2"])
+
+        @test_broken 35. ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]]) # now 60, should be 35 ? 30 ?
+
+        # active limits ?
+        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) # now 0, should be 1 ?
+        @test_broken 35. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) # now 0, should be 35 ?
+        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) # now 0, should be 1 ?
+        @test_broken 35. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"]) # now 0, should be 35 ?
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
+    end
+
+    #=
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                        |
+    (limitable) wind_1_1|load
+    Pmin=0, Pmax=100    | S1: 30
+    Csta=0, Cprop=1     | S2: 60
+      S1: 55            |
+      S2: 60            |
+    =#
+    @testset "tso_chooses_injection_level" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T10:00:00")
+        network = PSCOPF.Networks.Network()
+        # Buses
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        # initial generators state : need to pay starting cost at TS[1]
+        generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+        #ManagementMode
+        mode = PSCOPF.ManagementMode("test_mode", Dates.Minute(5))
+
+
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 30.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict(),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        tso = PSCOPF.TSOOutFO()
+
+        @test firmness == PSCOPF.compute_firmness(tso,
+                                                ech, DateTime("2015-01-01T10:40:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # Limit
+        @test 30. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S1"])
+        @test 60. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S2"])
+
+        @test 60. ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]])
+
+        # active limits ?
+        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) # now 0. should be 1 ?
+        @test_broken 35. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) < 1e-09 # now 0. should be 30 ? 35 ?
+        @test value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"]) < 1e-09
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
+    end
+
+    #=
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                        |
+    (limitable) wind_1_1|load
+    Pmin=0, Pmax=100    | S1: 30
+    Csta=0, Cprop=1     | S2: 60
+      S1: 70            |
+      S2: 60            |
+      uncertainty(S1) > limit
+    =#
+    @testset "tso_chooses_injection_level" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T10:00:00")
+        network = PSCOPF.Networks.Network()
+        # Buses
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        # initial generators state : need to pay starting cost at TS[1]
+        generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+        #ManagementMode
+        mode = PSCOPF.ManagementMode("test_mode", Dates.Minute(5))
+
+
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 70.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 30.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 60.)
+
+        # firmness
+        firmness = PSCOPF.Firmness(
+                SortedDict(),
+                SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                )
+
+        context = PSCOPF.PSCOPFContext(network, TS, mode,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        tso = PSCOPF.TSOOutFO()
+
+        @test firmness == PSCOPF.compute_firmness(tso,
+                                                ech, DateTime("2015-01-01T10:40:00"),
+                                                TS, context)
+
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        # Limit
+        @test 30. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S1"])
+        @test 60. ≈ value(result.limitable_model.p_injected["wind_1_1",TS[1],"S2"])
+
+        @test 70. ≈ value(result.limitable_model.p_limit["wind_1_1",TS[1]]) # should be 60 ? 70 ? 100 ?
+
+        # active limits ?
+        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S1"]) # now 0. should be 1 ?
+        @test_broken 30. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S1"]) # now 0. should be 30 ? 60 ? 70 ? 100 ?
+        @test_broken 1 ≈ value(result.limitable_model.b_is_limited["wind_1_1",TS[1], "S2"]) # now 0. should be 1 ?
+        @test_broken 60. ≈ value(result.limitable_model.p_limit_x_is_limited["wind_1_1",TS[1], "S2"])  # now 0. should be 60 ? 70 ? 100 ?
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
+    end
+
+
+end

--- a/test/test_wip/test_models/tso_out_fo/test_slacks.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_slacks.jl
@@ -9,28 +9,28 @@ using DataStructures
 
     #=
     Currently
-    Pinj = min(Plim, uncertainties)
-    so Pinj cannot be fixed to a level lower than uncertainties
+    If available power for a limitable exceeds consumption,
+      the TSO can choose a production level lower than the available
+      simply by choosing the injection.
+
                     S1   S2
     Load            15    25
     prod            20    25
-    we would like to have :
+    we have :
     Plim         =     25
     Pinj         = [15 , 25]
-    B_islim      = [0  , 0]
-    Pislim_x_lim = [0  , 0]
+    B_islim      = [1  , 0]
     cut_conso    = [0  , 0]
-    But now, we have :
+
+    Should we consider ?
+        Pinj = min(Plim, uncertainties)
+    so Pinj cannot be fixed to a level lower than uncertainties
+
     Plim         =     15
     Pinj         = [15 , 15]
     B_islim      = [0  , 1]
     Pislim_x_lim = [0  , 15]
     cut_conso    = [0  , 10]
-
-    FIXME ?
-    If available power for a limitable exceeds consumption,
-      the TSO can choose a production level lower than the available
-      simply by choosing the injection.
 
     TS: [11h]
     S: [S1]
@@ -100,7 +100,7 @@ using DataStructures
                 PSCOPF.get_uncertainties(uncertainties[ech], "wind_1_1", TS[1], "S2") )
         # We do not pay for capped power
         #If it was due to TSO constraints, we would have paid for the generator used instead of limitables
-        @test value(result.objective_model.penalty) < 1e-09
+        @test value(result.objective_model.penalty) < 0.5 # > 0 cause we have a limitation
         @test value(result.objective_model.start_cost) < 1e-09
         @test (15. + 25. ) ≈ value(result.objective_model.prop_cost)
     end
@@ -163,7 +163,7 @@ using DataStructures
                     context)
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
-        # TODO a status to indicate using slacks for feasibility
+        # indicates using slacks for feasibility
         @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         # S1 : prod_capacity < load => cannot satisfy demand
         @test 100. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "prod_1_1", TS[1], "S1")
@@ -183,8 +183,6 @@ using DataStructures
 
 
     #=
-    #FIXME c.f. tso_cant_cap_limitable_power_by_choosing_prod_level
-
     TS: [11h]
     S: [S1]
                         bus 1

--- a/test/test_wip/test_models/tso_out_fo/test_slacks.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_slacks.jl
@@ -164,7 +164,7 @@ using DataStructures
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
         # TODO a status to indicate using slacks for feasibility
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
         # S1 : prod_capacity < load => cannot satisfy demand
         @test 100. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "prod_1_1", TS[1], "S1")
         @test 50. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"])
@@ -253,8 +253,8 @@ using DataStructures
                     context)
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
-        # TODO a status to indicate using slacks for feasibility because of scenario S1
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        # indicates using slacks for feasibility (because of scenario S1)
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_HAS_SLACK
 
         # In S1 : Load=15, wind provides 10 => still missing 5 but pmin=20
         # => we want to reduce consumption by 5

--- a/test/test_wip/test_models/tso_out_fo/test_slacks.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_slacks.jl
@@ -1,0 +1,287 @@
+using PSCOPF
+
+using Test
+using JuMP
+using Dates
+using DataStructures
+
+@testset verbose=true "test_tso_slacks" begin
+
+    #=
+    Currently
+    Pinj = min(Plim, uncertainties)
+    so Pinj cannot be fixed to a level lower than uncertainties
+                    S1   S2
+    Load            15    25
+    prod            20    25
+    we would like to have :
+    Plim         =     25
+    Pinj         = [15 , 25]
+    B_islim      = [0  , 0]
+    Pislim_x_lim = [0  , 0]
+    cut_conso    = [0  , 0]
+    But now, we have :
+    Plim         =     15
+    Pinj         = [15 , 15]
+    B_islim      = [0  , 1]
+    Pislim_x_lim = [0  , 15]
+    cut_conso    = [0  , 10]
+
+    FIXME ?
+    If available power for a limitable exceeds consumption,
+      the TSO can choose a production level lower than the available
+      simply by choosing the injection.
+
+    TS: [11h]
+    S: [S1]
+                      bus 1
+                        |
+    (limitable) wind_1_1|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=1     |     load_1
+      S1: 20            | S1: 15
+      S2: 25            | S2: 25
+                        |
+    =#
+    @testset "tso_cant_cap_limitable_power_by_choosing_prod_level" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 25.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 25.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict{String, SortedDict{Dates.DateTime, PSCOPF.DecisionFirmness} }(),
+                    SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE))
+                    )
+        # initial generators state : No need because all pmin=0 => ON by default
+        generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T07:00:00"), SortedDict(
+            "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                SortedDict(),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>20.,"S2"=>25.)))
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL # We want FIXME
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL # We have FIXME
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+        @test_broken value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09 # We want
+        @test 10. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) # We have
+        # Limitable produces to the available level
+        @test 15. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S1")
+        @test_broken 25. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2") # We want
+        @test 15. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2") # We have
+        # Limitable was capped when prod > load (ie. S1):
+        @test -5. ≈ ( PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S1")
+                    - PSCOPF.get_uncertainties(uncertainties[ech], "wind_1_1", TS[1], "S1") )
+        @test ( PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2")
+                - PSCOPF.get_uncertainties(uncertainties[ech], "wind_1_1", TS[1], "S2") ) < 1e-09 # We want
+        @test -10. ≈ ( PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2")
+                    - PSCOPF.get_uncertainties(uncertainties[ech], "wind_1_1", TS[1], "S2") ) # We have
+        # We do not pay for capped power
+        #If it was due to TSO constraints, we would have paid for the generator used instead of limitables
+        @test_broken value(result.objective_model.penalty) < 1e-09 # We want
+        @test (10*1e7 + 1e-3) ≈ value(result.objective_model.penalty) # We have : 10 cut_conso + 1 limitation
+        @test value(result.objective_model.start_cost) < 1e-09
+        @test_broken (15. + 25. ) ≈ value(result.objective_model.prop_cost) # We want
+        @test (15. + 15. ) ≈ value(result.objective_model.prop_cost) # We have
+    end
+
+    #=
+    It is possible to cut consumption.
+    This variable can be used in two cases :
+    1- due to EOD constraints : we don't have enough production capacity (illustrated in S1)
+    2- due to Pmin constraints : we don't have enough demand to start a unit (illustrated in S2)
+    3- due to RSO constraints (c.f. tso_cuts_consumption_due_to_rso)
+
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                         |
+    (imposable) prod_1_1 |    load_1
+    Pmin=20, Pmax=100    |  S1: 150
+    Csta=100k, Cprop=1   |  S2: 15
+                         |  S3: 25
+    =#
+    @testset "tso_cuts_consumption_due_to_pmin" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Imposables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                                20., 100.,
+                                                100000., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 150.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 15.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S3", 25.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),),
+                    SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE))
+                    )
+        # initial generators state :
+        generators_init_state = SortedDict("prod_1_1" => PSCOPF.OFF)
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T07:00:00"), SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                        SortedDict("S1"=>PSCOPF.ON, "S2"=>PSCOPF.OFF, "S3"=>PSCOPF.ON))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>100.,"S2"=>0.,"S3"=>25.)))
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # TODO a status to indicate using slacks for feasibility
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+        # S1 : prod_capacity < load => cannot satisfy demand
+        @test 100. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "prod_1_1", TS[1], "S1")
+        @test 50. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"])
+        # S2 : load < pmin => cannot start the unit for such load
+        @test PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "prod_1_1", TS[1], "S2") < 1e-09
+        @test 15. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"])
+        # S3 : works fine
+        @test 25. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "prod_1_1", TS[1], "S3")
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S3"]) < 1e-09
+        # penalize cutting consumption
+        @test 1e7 ≈ tso.configs.cut_conso_penalty
+        @test (50. * 1e7 + 15. * 1e7 + 0. ) ≈ value(result.objective_model.penalty)
+        @test (0. + 0. + 0.) ≈ value(result.objective_model.start_cost) #The market paid for starting
+        @test (100. + 0. + 25. ) ≈ value(result.objective_model.prop_cost) #FIXME : pay just for the difference ? i.e. delta*prop_cost instead of injected*prop_cost
+    end
+
+
+    #=
+    #FIXME c.f. tso_cant_cap_limitable_power_by_choosing_prod_level
+
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                         |
+    (limitable) wind_1_1 |    load_1
+    Pmin=0, Pmax=100     |  S1: 15
+    Csta=0, Cprop=0.     |  S2: 25
+         S1 : 10         |
+         S1 : 10         |
+                         |
+    (imposable) prod_1_1 |
+    Pmin=20, Pmax=100    |
+    Csta=100k, Cprop=100 |
+    =#
+    @testset "tso_capping_limitables_due_to_imposable_pmin" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Imposables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Imposables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                                20., 100.,
+                                                100000., 100.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 10.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S2", 10.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 15.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 25.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),),
+                    SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                               "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE))
+                    )
+        # initial generators state :
+        generators_init_state = SortedDict("prod_1_1" => PSCOPF.OFF)
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T07:00:00"), SortedDict(
+            "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                SortedDict(),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>10.,"S2"=>10.)))
+            ),
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                        SortedDict("S1"=>PSCOPF.OFF, "S2"=>PSCOPF.ON))),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>20.)))
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # TODO a status to indicate using slacks for feasibility because of scenario S1
+        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL
+
+        # In S1 : Load=15, wind provides 10 => still missing 5 but pmin=20
+        # => we want to reduce consumption by 5
+        # But limit links the two scenarios and we can only produce to limit or uncertainty levels
+        @test_broken 10. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S1") # We want
+        @test 5. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S1") # We have
+        @test PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "prod_1_1", TS[1], "S1") < 1e-09
+        @test_broken 5. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) # We want
+        @test 10. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) # We have
+
+        # In S2 : Load=25, wind provides 10 => still missing 15 but pmin=20
+        # imposable produces 20 => 5 extra prod (20+10 - 25) => reduce wind by 5.
+        @test 5. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2")
+        @test 20. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "prod_1_1", TS[1], "S2")
+        @test -5. ≈ ( PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2")
+                    - PSCOPF.get_uncertainties(uncertainties[ech], "wind_1_1", TS[1], "S2") )
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
+    end
+
+
+    #TODO : illustrate ptdf effect
+
+end

--- a/test/test_wip/test_models/tso_out_fo/test_slacks.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_slacks.jl
@@ -43,7 +43,7 @@ using DataStructures
       S2: 25            | S2: 25
                         |
     =#
-    @testset "tso_cant_cap_limitable_power_by_choosing_prod_level" begin
+    @testset "tso_can_cap_limitable_power_by_choosing_prod_level" begin
         TS = [DateTime("2015-01-01T11:00:00")]
         ech = DateTime("2015-01-01T07:00:00")
         network = PSCOPF.Networks.Network()
@@ -87,29 +87,22 @@ using DataStructures
         PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
 
         # Solution is optimal
-        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL # We want FIXME
-        @test_broken PSCOPF.get_status(result) != PSCOPF.pscopf_OPTIMAL # We have FIXME
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
         @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
-        @test_broken value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09 # We want
-        @test 10. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) # We have
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S2"]) < 1e-09
         # Limitable produces to the available level
         @test 15. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S1")
-        @test_broken 25. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2") # We want
-        @test 15. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2") # We have
+        @test 25. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2")
         # Limitable was capped when prod > load (ie. S1):
         @test -5. ≈ ( PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S1")
                     - PSCOPF.get_uncertainties(uncertainties[ech], "wind_1_1", TS[1], "S1") )
-        @test ( PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2")
-                - PSCOPF.get_uncertainties(uncertainties[ech], "wind_1_1", TS[1], "S2") ) < 1e-09 # We want
-        @test -10. ≈ ( PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2")
-                    - PSCOPF.get_uncertainties(uncertainties[ech], "wind_1_1", TS[1], "S2") ) # We have
+        @test ( PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S2") ≈
+                PSCOPF.get_uncertainties(uncertainties[ech], "wind_1_1", TS[1], "S2") )
         # We do not pay for capped power
         #If it was due to TSO constraints, we would have paid for the generator used instead of limitables
-        @test_broken value(result.objective_model.penalty) < 1e-09 # We want
-        @test (10*1e7 + 1e-3) ≈ value(result.objective_model.penalty) # We have : 10 cut_conso + 1 limitation
+        @test value(result.objective_model.penalty) < 1e-09
         @test value(result.objective_model.start_cost) < 1e-09
-        @test_broken (15. + 25. ) ≈ value(result.objective_model.prop_cost) # We want
-        @test (15. + 15. ) ≈ value(result.objective_model.prop_cost) # We have
+        @test (15. + 25. ) ≈ value(result.objective_model.prop_cost)
     end
 
     #=
@@ -265,12 +258,9 @@ using DataStructures
 
         # In S1 : Load=15, wind provides 10 => still missing 5 but pmin=20
         # => we want to reduce consumption by 5
-        # But limit links the two scenarios and we can only produce to limit or uncertainty levels
-        @test_broken 10. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S1") # We want
-        @test 5. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S1") # We have
+        @test 10. ≈ PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "wind_1_1", TS[1], "S1")
         @test PSCOPF.get_prod_value(PSCOPF.get_tso_schedule(context), "prod_1_1", TS[1], "S1") < 1e-09
-        @test_broken 5. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) # We want
-        @test 10. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) # We have
+        @test 5. ≈ value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"])
 
         # In S2 : Load=25, wind provides 10 => still missing 15 but pmin=20
         # imposable produces 20 => 5 extra prod (20+10 - 25) => reduce wind by 5.

--- a/test/test_wip/test_models/tso_out_fo/test_start_cost.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_start_cost.jl
@@ -1,0 +1,807 @@
+using PSCOPF
+
+using Test
+using JuMP
+using Dates
+using DataStructures
+
+@testset verbose=true "test_tso_start_cost" begin
+
+
+    #=
+    TS: [11h, 11h15]
+    S: [S1,S2]
+                        bus 1
+                        |
+    (imposable) prod_1_1|          load_1
+    Pmin=10, Pmax=100   |S1: 30     S1: 50
+    Csta=45k, Cprop=10  |S2: 25     S2: 35
+                        |
+    (imposable) prod_1_2|
+     Pmin=10, Pmax=100  |
+     Csta=80k, Cprop=15 |
+    =#
+
+    TS = [DateTime("2015-01-01T11:00:00"), DateTime("2015-01-01T11:15:00")]
+    ech = DateTime("2015-01-01T07:00:00")
+    network = PSCOPF.Networks.Network()
+    # Buses
+    PSCOPF.Networks.add_new_bus!(network, "bus_1")
+    # Imposables
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                            10., 100.,
+                                            45000., 10.,
+                                            Dates.Second(0), Dates.Second(0))
+    PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_2", PSCOPF.Networks.IMPOSABLE,
+                                            10., 100.,
+                                            80000., 15.,
+                                            Dates.Second(0), Dates.Second(0))
+    # Uncertainties
+    uncertainties = PSCOPF.Uncertainties()
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 30.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S2", 25.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S1", 50.)
+    PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 35.)
+    # firmness
+    firmness = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE) ),
+                SortedDict( "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE), )
+                )
+
+    #=
+    prod_1_1 is ON, prod_1_2 is ON
+    Market has not set these units' levels
+    We only use prod_1_1 cause its prop cost is lower
+    =#
+    @testset "tso_no_starting_cost_if_units_initially_started" begin
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.ON,
+            "prod_1_2" => PSCOPF.ON
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test value(result.objective_model.start_cost) < 1e-09
+
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+    end
+
+    #=
+    prod_1_1 is OFF, prod_1_2 is ON
+    We only use prod_1_2 cause its already started => no start cost => cheaper
+    =#
+    @testset "tso_no_starting_cost_for_unit_prod_1_2" begin
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.OFF,
+            "prod_1_2" => PSCOPF.ON
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test value(result.objective_model.start_cost) < 1e-09
+        #high start cost for prod_1_1 => not used
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        #no start cost for prod_1_2 => used eventhough it's unitary prop_cost is higher
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+    end
+
+    #=
+    prod_1_1 is OFF, prod_1_2 is OFF
+    We only use prod_1_1 cause it's cheaper (mainly in terms of start cost)
+    =#
+    @testset "tso_starting_cost" begin
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.OFF,
+            "prod_1_2" => PSCOPF.OFF
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test 2*45000. ≈ value(result.objective_model.start_cost) # started in 2 scenarios
+
+        #start cost for prod_1_1 prefered to prod_1_2
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        #higher start cost for prod_1_2 => not used
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+    end
+
+    #=
+    Init : prod_1_1 is OFF, prod_1_2 is OFF
+    Market : uses prod_1_2 ; started (ON) and set the prod levels satisfying the EOD
+    We use prod_1_2 to follow the market, even if prod_1_1 is cheaper
+    =#
+    @testset "tso_starting_cost_due_to_following_market" begin
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.OFF,
+            "prod_1_2" => PSCOPF.OFF
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.ON, "S2"=>PSCOPF.ON)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.ON, "S2"=>PSCOPF.ON))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>30.,"S2"=>25.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>50.,"S2"=>35.)),
+                                                                                        )
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test 2*80000. ≈ value(result.objective_model.start_cost) # started in 2 scenarios
+        @test value(result.objective_model.deltas) < 1e-09 # followed the market
+
+        #start cost for prod_1_1 prefered to prod_1_2 but will cause high deviation from the market
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        #higher start cost for prod_1_2 but we follow the market
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+    end
+
+    #=
+    Init : prod_1_1 is OFF, prod_1_2 is OFF
+    Market : uses prod_1_2 ; started (ON) but didn't set the prod levels
+    => using prod_1_1 or prod_1_2 will have the same effect on deltas
+    We use prod_1_1 cause cheaper
+    =#
+    @testset "tso_starting_cost_deviate_from_market" begin
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.OFF,
+            "prod_1_2" => PSCOPF.OFF
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.ON, "S2"=>PSCOPF.ON)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.ON, "S2"=>PSCOPF.ON))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test 2*45000. ≈ value(result.objective_model.start_cost) # started in 2 scenarios
+        @test (30 + 25 + 50 + 35) ≈ value(result.objective_model.deltas)
+
+        #start cost for prod_1_1 prefered to prod_1_2
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        #higher start cost for prod_1_2 => not used
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+    end
+
+    #=
+    Init : prod_1_1 is OFF, prod_1_2 is OFF
+    Market : definitively starts prod_1_2
+    => if we use prod_1_2 we do not pay for starting
+    =#
+    @testset "tso_no_starting_cost_for_definitive_market_starts" begin
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.OFF,
+            "prod_1_2" => PSCOPF.OFF
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                        SortedDict("S2"=>PSCOPF.ON, "S2"=>PSCOPF.ON)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                        SortedDict("S2"=>PSCOPF.ON, "S2"=>PSCOPF.ON))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test value(result.objective_model.start_cost) <= 1e-09 # starting cost was paid by market
+
+        #start cost for prod_1_1 prefered to prod_1_2
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        #higher start cost for prod_1_2 => not used
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+    end
+
+    #=
+    Init : prod_1_1 is OFF, prod_1_2 is OFF
+    TSO already definitively started prod_1_2
+    => if we use prod_1_2 we do not pay for starting
+    =#
+    @testset "tso_no_starting_cost_for_past_definitive_tso_starts" begin
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.OFF,
+            "prod_1_2" => PSCOPF.OFF
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.OFF,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            )
+        )
+        context.tso_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                        SortedDict("S2"=>PSCOPF.ON, "S2"=>PSCOPF.ON)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                        SortedDict("S2"=>PSCOPF.ON, "S2"=>PSCOPF.ON))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            )
+        )
+        firmness_l = PSCOPF.Firmness(
+                SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.DECIDED,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.DECIDED) ),
+                SortedDict( "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE),
+                            "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE,
+                                                    Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.FREE), )
+                )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness_l,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness_l, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test value(result.objective_model.start_cost) <= 1e-09 # starting cost was paid by market
+
+        #start cost for prod_1_1 prefered to prod_1_2
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        #higher start cost for prod_1_2 => not used
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+    end
+
+    #=
+    TS: [11h, 11h15]
+    S: [S1,S2]
+                        bus 1
+                        |
+    (imposable) prod_1_1|          load_1
+    Pmin=10, Pmax=100   |S1: 30     S1: 50
+    Csta=45k, Cprop=10  |S2: 25     S2: 165
+                        |
+    (imposable) prod_1_2|
+     Pmin=10, Pmax=100  |
+     Csta=80k, Cprop=15 |
+
+    We have high demand for TS2, S2
+    =#
+
+    #=
+    both units are ON
+    In TS2,S2, we need both units
+    but in TS1 one unit is enough
+    => if we turn off a unit in TS1, we will need to restart it for TS2
+    => it's cheaper to use both units at TS1 non-optimally to get the global optimum
+    =#
+    @testset "tso_both_units_used_in_S2_to_avoid_restart_cost" begin
+        #bus2, S2, TS:11h15 : high demand
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 165.)
+
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.ON,
+            "prod_1_2" => PSCOPF.ON
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test value(result.objective_model.start_cost) <= 1e-09 # No start cost, in S2, prod_1_2 is used in TS1 to avoid restart
+
+        #start cost for prod_1_1 prefered to prod_1_2
+        @test 30. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test 15. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test 50. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test 100. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        #higher start cost for prod_1_2 => not used
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test 10. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test 65. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+
+        #reset original value
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 65.)
+    end
+
+    #=
+    both units are OFF
+    in TS1 one unit is enough => start prod_1_1
+    In TS2,S2, we need both units => start prod_1_2
+    =#
+    @testset "tso_both_units_are_started_when_needed" begin
+        #bus2, S2, TS:11h15 : high demand
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 165.)
+
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.OFF,
+            "prod_1_2" => PSCOPF.OFF
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                        SortedDict("S2"=>PSCOPF.OFF, "S2"=>PSCOPF.OFF))
+                            ),
+                SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                            Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                ),
+            )
+        )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test (2*45000 + 80000) ≈ value(result.objective_model.start_cost)  # prod1 started in 2 scenarios, prod2 in S2
+
+        # S1 : prod_1_1 is cheaper to start => used
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test 30. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test 50. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S1") < 1e-09
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[2], "S1") < 1e-09
+
+        # S2 : prod_1_2 is needed to satisfy demand it also has high proportional cost
+        # => prod_1_2 is only started when needed
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+        @test 25. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test 100. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S2") < 1e-09
+        @test 65. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+
+        #reset original value
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 65.)
+    end
+
+
+    #=
+    definitive starting decisions made in
+     the tso_schedule and the reference market schedule are gratis for the TSO
+    Here, in tso_schedule, we :
+        - consider starting prod_1_1  (non-definitive decision) => it is not gratis for market
+        - start prod_1_2 (definitive decision) => prod_1_2 has no start cost for market
+    =#
+    @testset "tso_test_gratis_start" begin
+        #bus2, S2, TS:11h15 : high demand
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 165.)
+
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.OFF,
+            "prod_1_2" => PSCOPF.OFF
+        )
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.TSO(), Dates.DateTime("2015-01-01T06:00:00"), SortedDict(
+                                        "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON, "S2"=>PSCOPF.ON)),
+                                                        Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(missing,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON, "S2"=>PSCOPF.ON))
+                                                        ),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                        Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                                            ),
+                                        "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON, "S2"=>PSCOPF.ON)),
+                                                        Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                                                    SortedDict("S1"=>PSCOPF.ON, "S2"=>PSCOPF.ON))
+                                                        ),
+                                            SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                        Dates.DateTime("2015-01-01T11:15:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                        SortedDict("S1"=>0.,"S2"=>0.)),
+                                                                                        )
+                                            )
+                                        )
+                                )
+
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+        @test (45000) ≈ value(result.objective_model.start_cost)  # prod1 started in 2 scenarios, prod2 in S2
+        @test( value(result.objective_model.prop_cost) ≈
+              (   (0.   *10. + 30. * 15) #TS1, S1
+                + (0.   *10. + 50. * 15) #TS2, S1
+                + (15.  *10. + 10.  * 15) #TS1, S2
+                + (100. *10. + 65. * 15) #TS2, S2
+              )
+        )
+
+        #S1 : need one generator, prod_1_2 can be started gratis => no need to start prod_1_1
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test PSCOPF.OFF == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+        @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[2], "S1") < 1e-09
+        @test 30. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+        @test 50. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[2], "S1")
+        #S2 : need both generators at TS2, prod_1_2 can be started gratis at TS1
+        # => we use prod_1_2 since ts1, to get its free starting (starting it at TS2 would cost less prop_cost but <e would pay for starting)
+        # prod_1_1 is use right from TS1 even if not really needed cause we will pay for starting anyways, so at least use it at TS1 to reduce prop_cost
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+        @test 15. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S2")
+        @test 10. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S2")
+        @test 100. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[2], "S2")
+        @test 65. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[2], "S2")
+
+        #reset original value
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:15:00"), "S2", 65.)
+    end
+
+end

--- a/test/test_wip/test_models/tso_out_fo/test_unit_priority.jl
+++ b/test/test_wip/test_models/tso_out_fo/test_unit_priority.jl
@@ -1,0 +1,310 @@
+using PSCOPF
+
+using Test
+using JuMP
+using Dates
+using DataStructures
+
+@testset verbose=true "test_tso_unit_priority" begin
+
+    #=
+    TSOOutFO tries to deviate the least from the reference market schedule.
+    Then, while respecting this deviation, chooses the cheapest units.
+
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                        |
+    (limitable) wind_1_1|load_2
+    Pmin=0, Pmax=100    | S1: 55
+    Csta=0, Cprop=150   |
+      S1: 20            |
+                        |
+    (limitable) wind_1_2|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=1     |
+      S1: 25            |
+                        |
+    (imposable) prod_1_1|
+    Pmin=0, Pmax=100    |
+    Csta=0, Cprop=10    |
+                        |
+    (imposable) prod_1_2|
+     Pmin=0, Pmax=100   |
+     Csta=0, Cprop=15   |
+                        |
+    =#
+    @testset "tso_deviates_the_least_from_market" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        # Buses
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 150.,
+                                                Dates.Second(0), Dates.Second(0))
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_2", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Imposables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                                0., 100.,
+                                                0., 10.,
+                                                Dates.Second(0), Dates.Second(0))
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_2", PSCOPF.Networks.IMPOSABLE,
+                                                0., 100.,
+                                                0., 15.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 20.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_2", DateTime("2015-01-01T11:00:00"), "S1", 25.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict{String, SortedDict{Dates.DateTime, PSCOPF.DecisionFirmness} }(),
+                    SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                                "wind_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                                "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                                "prod_1_2" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                    )
+        # initial generators state : No need because all pmin=0 => ON by default
+        generators_init_state = SortedDict{String, PSCOPF.GeneratorState}()
+
+
+        @testset "tso_follows_market_even_if_its_expensive" begin
+            #=
+            Market uses the more expensive unit prod_1_2
+            =#
+            context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                            generators_init_state,
+                                            uncertainties, nothing)
+            context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T10:45:00"), SortedDict(
+                    "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                        SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                        SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                SortedDict("S1"=>20.)))
+                        ),
+                    "wind_1_2" => PSCOPF.GeneratorSchedule("wind_1_2",
+                        SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                        SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                SortedDict("S1"=>25.)))
+                    ),
+                    "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                        SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                        SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                SortedDict("S1"=>0.)))
+                    ),
+                    "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                        SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                        SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                SortedDict("S1"=>10.)))
+                    ),
+                    )
+            )
+
+            tso = PSCOPF.TSOOutFO()
+            result = PSCOPF.run(tso, ech, firmness,
+                        PSCOPF.get_target_timepoints(context),
+                        context)
+            PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+            # Solution is optimal
+            @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+
+            @test value(result.objective_model.deltas) < 1e-09 # followed the market
+            @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+
+            @test 20. ≈ PSCOPF.get_prod_value(context.tso_schedule, "wind_1_1", TS[1], "S1")
+            @test 25. ≈ PSCOPF.get_prod_value(context.tso_schedule, "wind_1_2", TS[1], "S1")
+            @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") < 1e-09
+            @test 10. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+
+            # pmin = 0 for prod_1_1 & prod_2_1
+            @test ismissing( PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1") )
+            @test ismissing( PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1") )
+        end
+
+        @testset "tso_follows_market_while_choosing_the_cheapest" begin
+            #=
+            Market uses the more expensive unit prod_1_2
+            5MW are missing => To respect EOD, TSO will increase prod by 5
+            => deviation from market
+            TSO will use prod_1_1 & prod_1_2 cause that is cheaper
+            =#
+            context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                            generators_init_state,
+                                            uncertainties, nothing)
+            context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), Dates.DateTime("2015-01-01T10:45:00"), SortedDict(
+                    "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                        SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                        SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                SortedDict("S1"=>20.)))
+                        ),
+                    "wind_1_2" => PSCOPF.GeneratorSchedule("wind_1_2",
+                        SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                        SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                SortedDict("S1"=>25.)))
+                    ),
+                    "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                        SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                        SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                SortedDict("S1"=>0.)))
+                    ),
+                    "prod_1_2" => PSCOPF.GeneratorSchedule("prod_1_2",
+                        SortedDict{Dates.DateTime, PSCOPF.UncertainValue{PSCOPF.GeneratorState}}(),
+                        SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.UncertainValue{Float64}(missing,
+                                                                                                SortedDict("S1"=>5.)))
+                    ),
+                    )
+            )
+
+            tso = PSCOPF.TSOOutFO()
+            result = PSCOPF.run(tso, ech, firmness,
+                        PSCOPF.get_target_timepoints(context),
+                        context)
+            PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+            # Solution is optimal
+            @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+
+            @test 5. ≈ value(result.objective_model.deltas)
+            @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+
+            @test 20. ≈ PSCOPF.get_prod_value(context.tso_schedule, "wind_1_1", TS[1], "S1")
+            @test 25. ≈ PSCOPF.get_prod_value(context.tso_schedule, "wind_1_2", TS[1], "S1")
+            @test 5. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+            @test 5. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S1")
+
+            # pmin = 0 for prod_1_1 & prod_2_1
+            @test ismissing( PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1") )
+            @test ismissing( PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1") )
+        end
+
+        @testset "tso_empty_market_schedule" begin
+            #=
+            If market_schedule is empty
+            consider that reference is 0.
+            Deviate the least from market (not important in this case since cutting conso is highly penalized)
+            Choose cheapest alternative
+            =#
+            context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                            generators_init_state,
+                                            uncertainties, nothing)
+
+            tso = PSCOPF.TSOOutFO()
+            result = PSCOPF.run(tso, ech, firmness,
+                        PSCOPF.get_target_timepoints(context),
+                        context)
+            PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+            # Solution is optimal
+            @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+
+            @test 55. ≈ value(result.objective_model.deltas)
+            @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+
+            @test 25. ≈ PSCOPF.get_prod_value(context.tso_schedule, "wind_1_2", TS[1], "S1") #Cprop=1
+            @test 30. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1") #Cprop=10
+            @test PSCOPF.get_prod_value(context.tso_schedule, "prod_1_2", TS[1], "S1") < 1e-09 #Cprop=15
+            @test PSCOPF.get_prod_value(context.tso_schedule, "wind_1_1", TS[1], "S1") <= 1e-09 #Cprop=150
+
+            # pmin = 0 for prod_1_1 & prod_2_1
+            @test ismissing( PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1") )
+            @test ismissing( PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_2", TS[1], "S1") )
+        end
+
+    end
+
+
+    #=
+    TS: [11h]
+    S: [S1]
+                        bus 1
+                        |
+    (limitable) wind_1_1|load_2
+    Pmin=0, Pmax=100    | S1: 55
+    Csta=0, Cprop=1     |
+      S1: 45            |
+                        |
+    (imposable) prod_1_1|
+    Pmin=20, Pmax=100   |
+    Csta=0, Cprop=10    |
+                        |
+    =#
+    @testset "tso_respects_pmin" begin
+        TS = [DateTime("2015-01-01T11:00:00")]
+        ech = DateTime("2015-01-01T07:00:00")
+        network = PSCOPF.Networks.Network()
+        # Buses
+        PSCOPF.Networks.add_new_bus!(network, "bus_1")
+        # Limitables
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "wind_1_1", PSCOPF.Networks.LIMITABLE,
+                                                0., 100.,
+                                                0., 1.,
+                                                Dates.Second(0), Dates.Second(0))
+        # Imposables : have a Pmin but no start cost
+        PSCOPF.Networks.add_new_generator_to_bus!(network, "bus_1", "prod_1_1", PSCOPF.Networks.IMPOSABLE,
+                                                20., 100.,
+                                                0., 10.,
+                                                Dates.Second(0), Dates.Second(0))
+
+        # Uncertainties
+        uncertainties = PSCOPF.Uncertainties()
+        PSCOPF.add_uncertainty!(uncertainties, ech, "wind_1_1", DateTime("2015-01-01T11:00:00"), "S1", 45.)
+        PSCOPF.add_uncertainty!(uncertainties, ech, "bus_1", DateTime("2015-01-01T11:00:00"), "S1", 55.)
+        # firmness
+        firmness = PSCOPF.Firmness(
+                    SortedDict("prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                            ),
+                    SortedDict("wind_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE),
+                                "prod_1_1" => SortedDict(Dates.DateTime("2015-01-01T11:00:00") => PSCOPF.FREE), )
+                    )
+        # initial generators state
+        generators_init_state = SortedDict(
+            "prod_1_1" => PSCOPF.OFF,
+        )
+
+        context = PSCOPF.PSCOPFContext(network, TS, PSCOPF.PSCOPF_MODE_1,
+                                        generators_init_state,
+                                        uncertainties, nothing)
+        context.market_schedule = PSCOPF.Schedule(PSCOPF.Market(), ech, SortedDict(
+            "wind_1_1" => PSCOPF.GeneratorSchedule("wind_1_1",
+                SortedDict(),
+                SortedDict( TS[1] => PSCOPF.UncertainValue{Float64}(missing,
+                                                                    SortedDict("S1"=>45.)))
+            ),
+            "prod_1_1" => PSCOPF.GeneratorSchedule("prod_1_1",
+                SortedDict(TS[1] => PSCOPF.UncertainValue{PSCOPF.GeneratorState}(PSCOPF.ON,
+                                                                                SortedDict("S1"=>PSCOPF.ON))),
+                SortedDict(TS[1] => PSCOPF.UncertainValue{Float64}(missing,
+                                                                    SortedDict("S1"=>10.))) # does not respect Pmin=20
+                ),
+            )
+        )
+        tso = PSCOPF.TSOOutFO()
+        result = PSCOPF.run(tso, ech, firmness,
+                    PSCOPF.get_target_timepoints(context),
+                    context)
+        PSCOPF.update_tso_schedule!(context, ech, result, firmness, tso)
+
+        # Solution is optimal
+        @test PSCOPF.get_status(result) == PSCOPF.pscopf_OPTIMAL
+
+        @test 20. ≈ value(result.objective_model.deltas)
+        @test value(result.slack_model.p_cut_conso["bus_1", TS[1], "S1"]) < 1e-09
+
+        @test 35. ≈ PSCOPF.get_prod_value(context.tso_schedule, "wind_1_1", TS[1], "S1")
+        @test PSCOPF.ON == PSCOPF.get_commitment_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+        @test 20. ≈ PSCOPF.get_prod_value(context.tso_schedule, "prod_1_1", TS[1], "S1")
+
+        @test value(result.objective_model.start_cost) < 1e-09 # prod_1_1 started by the market
+        @test value(result.objective_model.prop_cost) ≈ (
+              (35. * 1 + 20. * 10.)
+        )
+    end
+
+end

--- a/test/test_wip/test_tso_actions.jl
+++ b/test/test_wip/test_tso_actions.jl
@@ -16,22 +16,31 @@ using Dates
 
         @test isempty( PSCOPF.get_impositions(tso_actions) )
         @test ismissing( PSCOPF.get_imposition(tso_actions, "imp", ts) )
+
+        @test isempty( PSCOPF.get_commitments(tso_actions) )
+        @test ismissing( PSCOPF.get_commitment(tso_actions, "imp", ts) )
     end
 
     @testset "definitive_value" begin
         tso_actions = PSCOPF.TSOActions()
         PSCOPF.set_limitation_value!(tso_actions, "lim_1", ts, 300.)
         PSCOPF.set_limitation_value!(tso_actions, "lim_2", ts, 90.)
-        PSCOPF.set_imposition_value!(tso_actions, "imp", ts, 50.)
+        PSCOPF.set_imposition_value!(tso_actions, "imp", ts, 2.)
         PSCOPF.set_imposition_value!(tso_actions, "imp", ts2, 55.)
+        PSCOPF.set_commitment_value!(tso_actions, "imp", ts, PSCOPF.OFF) #careful : no coherence check, imposition_value is 2. but generator is off
+        PSCOPF.set_commitment_value!(tso_actions, "imp", ts2, PSCOPF.ON)
 
         @test length( PSCOPF.get_limitations(tso_actions) ) == 2
         @test PSCOPF.get_limitation(tso_actions, "lim_1", ts) == 300.
         @test PSCOPF.get_limitation(tso_actions, "lim_2", ts) == 90.
 
         @test length( PSCOPF.get_impositions(tso_actions) ) == 2
-        @test PSCOPF.get_imposition(tso_actions, "imp", ts) == 50.
+        @test PSCOPF.get_imposition(tso_actions, "imp", ts) == 2.
         @test PSCOPF.get_imposition(tso_actions, "imp", ts2) == 55.
+
+        @test length( PSCOPF.get_commitments(tso_actions) ) == 2
+        @test PSCOPF.get_commitment(tso_actions, "imp", ts) == PSCOPF.OFF
+        @test PSCOPF.get_commitment(tso_actions, "imp", ts2) == PSCOPF.ON
     end
 
 end


### PR DESCRIPTION
- Slack variables for Energy Market
- Possibility to shutdown a unit that was decided to be ON at DMO
- Implementation of the TSO for mode 1 (Limitable model still needs to be modified)
- Additional temporary output file to sum up consumption/load shedding, capping (fr. écrêtement),...
- Docs were not updated  